### PR TITLE
[Feature] S3 이미지 저장, 삭제 기능 구현

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/global/config/S3Config.java
+++ b/src/main/java/dormitoryfamily/doomz/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package dormitoryfamily.doomz.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -6,6 +6,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    // S3
+    FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+    FILE_EMPTY(HttpStatus.BAD_REQUEST, "첨부 파일이 없습니다."),
+    FILE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "삭제할 파일이 저장 공간에 존재하지 않습니다."),
+    MAX_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "허용 용량을 초과한 파일입니다."),
+
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/controller/S3Controller.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/controller/S3Controller.java
@@ -1,0 +1,36 @@
+package dormitoryfamily.doomz.global.util.s3.controller;
+
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import dormitoryfamily.doomz.global.util.s3.response.S3UploadResponseDto;
+import dormitoryfamily.doomz.global.util.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@Component
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/api/images")
+    public ResponseEntity<ResponseDto<S3UploadResponseDto>> uploadImage(
+            @RequestPart("file") MultipartFile multipartFile) throws IOException {
+
+        ResponseDto<S3UploadResponseDto> responseDto = ResponseDto.okWithData(s3Service.saveImage(multipartFile));
+        return ResponseEntity.status(responseDto.getCode()).body(responseDto);
+    }
+
+    @DeleteMapping("/api/images")
+    public ResponseEntity<ResponseDto> deleteImage(@RequestParam("imageUrl") String imageUrl) {
+
+        s3Service.removeImage(imageUrl);
+        ResponseDto<Void> responseDTO = ResponseDto.ok();
+        return ResponseEntity.status(responseDTO.getCode()).body(responseDTO);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/controller/S3ControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/controller/S3ControllerAdvice.java
@@ -1,0 +1,41 @@
+package dormitoryfamily.doomz.global.util.s3.controller;
+
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import dormitoryfamily.doomz.global.util.s3.exception.FileEmptyException;
+import dormitoryfamily.doomz.global.util.s3.exception.FileNotExistsException;
+import dormitoryfamily.doomz.global.util.s3.exception.FileUploadFailException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class S3ControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> fileUploadExceptionHandler(FileUploadFailException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> fileEmptyExceptionHandler(FileEmptyException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> fileNotExistsExceptionHandler(FileNotExistsException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileEmptyException.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileEmptyException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.global.util.s3.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class FileEmptyException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.FILE_EMPTY;
+
+    public FileEmptyException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileMaxSizeExceededException.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileMaxSizeExceededException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.global.util.s3.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class FileMaxSizeExceededException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.MAX_SIZE_EXCEEDED;
+
+    public FileMaxSizeExceededException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileNotExistsException.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileNotExistsException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.global.util.s3.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class FileNotExistsException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.FILE_NOT_EXISTS;
+
+    public FileNotExistsException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileUploadFailException.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/exception/FileUploadFailException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.global.util.s3.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class FileUploadFailException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.FILE_UPLOAD_FAIL;
+
+    public FileUploadFailException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/response/S3UploadResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/response/S3UploadResponseDto.java
@@ -1,0 +1,9 @@
+package dormitoryfamily.doomz.global.util.s3.response;
+
+public record S3UploadResponseDto(
+        String imageUrl
+) {
+    public S3UploadResponseDto(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/util/s3/service/S3Service.java
+++ b/src/main/java/dormitoryfamily/doomz/global/util/s3/service/S3Service.java
@@ -1,0 +1,73 @@
+package dormitoryfamily.doomz.global.util.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import dormitoryfamily.doomz.global.util.s3.exception.FileEmptyException;
+import dormitoryfamily.doomz.global.util.s3.exception.FileNotExistsException;
+import dormitoryfamily.doomz.global.util.s3.exception.FileUploadFailException;
+import dormitoryfamily.doomz.global.util.s3.response.S3UploadResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3Client amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public S3UploadResponseDto saveImage(MultipartFile multipartFile) {
+        validateFileExists(multipartFile);
+        String filename = generateFilename(multipartFile);
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3.putObject(bucketName, filename, inputStream, getObjectMetadata(multipartFile));
+        } catch (IOException e) {
+            throw new FileUploadFailException();
+        }
+        return new S3UploadResponseDto(amazonS3.getUrl(bucketName, filename).toString());
+    }
+
+    private String generateFilename(MultipartFile multipartFile) {
+        return UUID.randomUUID() + "_" + multipartFile.getOriginalFilename();
+    }
+
+    private ObjectMetadata getObjectMetadata(MultipartFile multipartFile) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+        return metadata;
+    }
+
+    public void removeImage(String url) {
+        String filename = getFilename(url);
+        if (!amazonS3.doesObjectExist(bucketName, filename)) {
+            throw new FileNotExistsException();
+        }
+
+        amazonS3.deleteObject(bucketName, filename);
+    }
+
+    private String getFilename(String url) {
+        String encodedName = url.substring(url.lastIndexOf("/") + 1);
+        try {
+            return URLDecoder.decode(encodedName, StandardCharsets.UTF_8.toString());
+        } catch (Exception e) {}
+        return "";
+    }
+
+    private void validateFileExists(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) {
+            throw new FileEmptyException();
+        }
+    }
+}


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)

### - **간략한 설명**
  - S3 이미지를 저장하고 삭제하는 API를 추가했습니다.

---

## 🛠 주요 작성/변경 사항

### - S3 이미지 추가 기능
  - 프론트에서 S3에 저장하고 싶은 이미지 한 장을 저장하는 요청을 보내면 S3 저장 URL을 반환합니다.

### - S3 이미지 삭제 기능
  - 특정 이미지 URL을 전달하면 S3에 저장된 해당 이미지를 삭제합니다.

---

## 💡 특이 사항 및 고민사항

### - 중복 이미지를 등록할 수 있도록 UUID를 이용해 이미지명을 변경합니다.
### - 개발용과 서비스용으로 구분지어 S3 버킷을 두 개 만들었습니다.
  - AWS_S3_DEV_BUCKET
  - AWS_S3_BUCKET

---

## 🔗 관련 이슈

- **이슈 링크** : #5 
