### PR TITLE
[Feature] 댓글과 대댓글 CRUD 기능 구현

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/entity/Article.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/entity/Article.java
@@ -73,6 +73,14 @@ public class Article extends BaseTimeEntity {
         this.wishCount = wishCount;
     }
 
+    public void increaseCommentCount(){
+        this.commentCount += 1;
+    }
+
+    public void decreaseCommentCount(){
+        this.commentCount -= 1;
+    }
+
     public void plusViewCount() {
         viewCount += 1;
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -41,18 +41,4 @@ public class CommentController {
         return ResponseEntity.ok(ResponseDto.ok());
     }
 
-    @PostMapping("/comments/{commentId}/replyComments")
-    public ResponseEntity<ResponseDto<CreateCommentResponseDto>> saveReplyComment(
-            @PathVariable Long commentId,
-            @RequestBody CreateCommentRequestDto requestDto
-    ) {
-        // 삭제 예정
-        Member member = new Member();
-        member.setId(1L);
-
-        CreateCommentResponseDto responseDto = commentService.saveChildComment(member, commentId, requestDto);
-        return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
-    }
-
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -17,7 +17,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/articles/{articleId}/comments")
-    public ResponseEntity<ResponseDto<CreateCommentResponseDto>> registerComment(
+    public ResponseEntity<ResponseDto<CreateCommentResponseDto>> saveComment(
             @PathVariable Long articleId,
             @RequestBody CreateCommentRequestDto requestDto
     ) {
@@ -25,7 +25,7 @@ public class CommentController {
         Member member = new Member();
         member.setId(1L);
 
-        CreateCommentResponseDto responseDto = commentService.save(articleId, member, requestDto);
+        CreateCommentResponseDto responseDto = commentService.saveComment(articleId, member, requestDto);
         return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
     }
 
@@ -40,5 +40,19 @@ public class CommentController {
         commentService.removeComment(member, commentId);
         return ResponseEntity.ok(ResponseDto.ok());
     }
+
+    @PostMapping("/comments/{commentId}/replyComments")
+    public ResponseEntity<ResponseDto<CreateCommentResponseDto>> saveReplyComment(
+            @PathVariable Long commentId,
+            @RequestBody CreateCommentRequestDto requestDto
+    ) {
+        // 삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        CreateCommentResponseDto responseDto = commentService.saveChildComment(member, commentId, requestDto);
+        return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
+    }
+
 
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -1,0 +1,32 @@
+package dormitoryfamily.doomz.domain.comment.controller;
+
+import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
+import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
+import dormitoryfamily.doomz.domain.comment.service.CommentService;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/articles/{articleId}")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/comments")
+    public ResponseEntity<ResponseDto<CreateCommentResponseDto>> registerComment(
+            @PathVariable Long articleId,
+            @RequestBody CreateCommentRequestDto requestDto
+    ) {
+        // 삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        CreateCommentResponseDto responseDto = commentService.save(articleId, member, requestDto);
+        return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
+    }
+
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package dormitoryfamily.doomz.domain.comment.controller;
 
 import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
+import dormitoryfamily.doomz.domain.comment.dto.response.CommentListResponseDto;
 import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
 import dormitoryfamily.doomz.domain.comment.service.CommentService;
 import dormitoryfamily.doomz.domain.member.entity.Member;
@@ -27,6 +28,18 @@ public class CommentController {
 
         CreateCommentResponseDto responseDto = commentService.saveComment(articleId, member, requestDto);
         return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
+    }
+
+    @GetMapping("/articles/{articleId}/comments")
+    public ResponseEntity<ResponseDto<CommentListResponseDto>> getComments(
+            @PathVariable Long articleId
+    ){
+        //삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        CommentListResponseDto responseDto= commentService.getCommentList(articleId, member);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 
     @DeleteMapping("/comments/{commentId}")

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -11,12 +11,12 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/articles/{articleId}")
+@RequestMapping("/api")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/comments")
+    @PostMapping("/articles/{articleId}/comments")
     public ResponseEntity<ResponseDto<CreateCommentResponseDto>> registerComment(
             @PathVariable Long articleId,
             @RequestBody CreateCommentRequestDto requestDto
@@ -27,6 +27,18 @@ public class CommentController {
 
         CreateCommentResponseDto responseDto = commentService.save(articleId, member, requestDto);
         return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ResponseDto<Void>> deleteComment(
+            @PathVariable Long commentId
+    ) {
+        // 삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        commentService.removeComment(member, commentId);
+        return ResponseEntity.ok(ResponseDto.ok());
     }
 
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentControllerAdvice.java
@@ -1,5 +1,6 @@
 package dormitoryfamily.doomz.domain.comment.controller;
 
+import dormitoryfamily.doomz.domain.comment.exception.CommentIsDeletedException;
 import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.global.util.ResponseDto;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,15 @@ public class CommentControllerAdvice {
 
     @ExceptionHandler
     public ResponseEntity<ResponseDto<Void>> handleCommentNotExistsException(CommentNotExistsException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleCommentIsDeleted(CommentIsDeletedException e) {
         HttpStatus status = e.getErrorCode().getHttpStatus();
 
         return ResponseEntity

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentControllerAdvice.java
@@ -1,6 +1,5 @@
 package dormitoryfamily.doomz.domain.comment.controller;
 
-import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
 import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.global.util.ResponseDto;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentControllerAdvice.java
@@ -1,0 +1,20 @@
+package dormitoryfamily.doomz.domain.comment.controller;
+
+import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
+import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+public class CommentControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleCommentNotExistsException(CommentNotExistsException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
@@ -10,10 +10,20 @@ public record CreateCommentRequestDto (
         @NotNull(message = "댓글 내용은 null일 수 없습니다.")
         String content
 ){
-    public static Comment toEntity(Member member, Article article, CreateCommentRequestDto requestDto){
+    public static Comment toComment(Member member, Article article, CreateCommentRequestDto requestDto){
         return Comment.builder()
                 .article(article)
                 .member(member)
+                .content(requestDto.content())
+                .isDeleted(false)
+                .build();
+    }
+
+    public static Comment toChildComment(Member member, Comment parentComment, CreateCommentRequestDto requestDto){
+        return Comment.builder()
+                .article(parentComment.getArticle())
+                .member(member)
+                .parentComment(parentComment)
                 .content(requestDto.content())
                 .isDeleted(false)
                 .build();

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
@@ -10,20 +10,10 @@ public record CreateCommentRequestDto (
         @NotNull(message = "댓글 내용은 null일 수 없습니다.")
         String content
 ){
-    public static Comment toComment(Member member, Article article, CreateCommentRequestDto requestDto){
+    public static Comment toEntity(Member member, Article article, CreateCommentRequestDto requestDto){
         return Comment.builder()
                 .article(article)
                 .member(member)
-                .content(requestDto.content())
-                .isDeleted(false)
-                .build();
-    }
-
-    public static Comment toChildComment(Member member, Comment parentComment, CreateCommentRequestDto requestDto){
-        return Comment.builder()
-                .article(parentComment.getArticle())
-                .member(member)
-                .parentComment(parentComment)
                 .content(requestDto.content())
                 .isDeleted(false)
                 .build();

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
@@ -1,0 +1,22 @@
+package dormitoryfamily.doomz.domain.comment.dto.request;
+
+
+import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateCommentRequestDto (
+        @NotNull(message = "댓글 내용은 null일 수 없습니다.")
+        String content
+){
+    public static Comment toEntity(Member member, Article article, CreateCommentRequestDto requestDto){
+        return Comment.builder()
+                .article(article)
+                .member(member)
+                .content(requestDto.content())
+                .isDeleted(false)
+                .build();
+    }
+}
+

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
@@ -1,6 +1,5 @@
 package dormitoryfamily.doomz.domain.comment.dto.request;
 
-
 import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentListResponseDto.java
@@ -1,0 +1,12 @@
+package dormitoryfamily.doomz.domain.comment.dto.response;
+
+import java.util.List;
+
+public record CommentListResponseDto (
+    int totalCount,
+    List<CommentResponseDto> comments
+){
+    public static CommentListResponseDto toDto(int totalCount, List<CommentResponseDto> comments) {
+        return new CommentListResponseDto(totalCount, comments);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -1,12 +1,14 @@
 package dormitoryfamily.doomz.domain.comment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.dto.response.ReplyCommentResponseDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
@@ -23,7 +25,7 @@ public record CommentResponseDto (
         boolean isDeleted,
         List<ReplyCommentResponseDto> replyComments
 ){
-    public static CommentResponseDto fromEntity(Member member, Comment comment){
+    public static CommentResponseDto fromEntity(Member loginMember, Article article, Comment comment){
         return new CommentResponseDto(
                 comment.getId(),
                 comment.getMember().getId(),
@@ -31,11 +33,15 @@ public record CommentResponseDto (
                 comment.getMember().getNickname(),
                 comment.getCreatedAt(),
                 comment.getContent(),
-                false,//추후 수정
+                isArticleWriter(loginMember, comment.getMember()),
                 comment.isDeleted(),
                 comment.getReplyComments().stream()
-                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(member, replyComment))
+                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(loginMember, article, replyComment))
                         .collect(toList())
         );
+    }
+
+    private static boolean isArticleWriter(Member loginMember, Member ArticleWriter) {
+        return Objects.equals(loginMember.getId(), ArticleWriter.getId());
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -26,9 +26,9 @@ public record CommentResponseDto (
     public static CommentResponseDto fromEntity(Member member, Comment comment){
         return new CommentResponseDto(
                 comment.getId(),
-                member.getId(),
-                member.getProfileUrl(),
-                member.getNickname(),
+                comment.getMember().getId(),
+                comment.getMember().getProfileUrl(),
+                comment.getMember().getNickname(),
                 comment.getCreatedAt(),
                 comment.getContent(),
                 false,//추후 수정

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,41 @@
+package dormitoryfamily.doomz.domain.comment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.replyComment.dto.response.ReplyCommentResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+public record CommentResponseDto (
+        Long commentId,
+        Long memberId,
+        String profileUrl,
+        String nickname,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
+        LocalDateTime createdAt,
+        String content,
+        boolean isWriter,
+        boolean isDeleted,
+        List<ReplyCommentResponseDto> replyComments
+){
+    public static CommentResponseDto fromEntity(Member member, Comment comment){
+        return new CommentResponseDto(
+                comment.getId(),
+                member.getId(),
+                member.getProfileUrl(),
+                member.getNickname(),
+                comment.getCreatedAt(),
+                comment.getContent(),
+                false,//추후 수정
+                comment.isDeleted(),
+                comment.getReplyComments().stream()
+                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(member, replyComment))
+                        .collect(toList())
+        );
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CreateCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CreateCommentResponseDto.java
@@ -1,0 +1,11 @@
+package dormitoryfamily.doomz.domain.comment.dto.response;
+
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+
+public record CreateCommentResponseDto (
+    Long commentId
+) {
+    public static CreateCommentResponseDto fromEntity(Comment comment) {
+        return new CreateCommentResponseDto(comment.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
@@ -50,4 +50,8 @@ public class Comment extends BaseTimeEntity {
         this.isDeleted = isDeleted;
     }
 
+    public void markAsDeleted(){
+        this.isDeleted=true;
+    }
+
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
@@ -9,6 +9,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
@@ -33,12 +36,20 @@ public class Comment extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
+    private List<Comment> childComments = new ArrayList<>();
+
     private boolean isDeleted;
 
     @Builder
-    public Comment(Article article, Member member, String content, boolean isDeleted) {
+    public Comment(Article article, Member member, Comment parentComment, String content, boolean isDeleted) {
         this.article = article;
         this.member = member;
+        this.parentComment = parentComment;
         this.content = content;
         this.isDeleted = isDeleted;
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
@@ -1,0 +1,46 @@
+package dormitoryfamily.doomz.domain.comment.entity;
+
+import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment")
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String content;
+
+    private boolean isDeleted;
+
+    @Builder
+    public Comment(Article article, Member member, String content, boolean isDeleted) {
+        this.article = article;
+        this.member = member;
+        this.content = content;
+        this.isDeleted = isDeleted;
+    }
+
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
@@ -38,6 +38,7 @@ public class Comment extends BaseTimeEntity {
     private String content;
 
     @OneToMany(mappedBy = "comment")
+    @OrderBy("createdAt ASC")
     private List<ReplyComment> replyComments  = new ArrayList<>();
 
     private boolean isDeleted;

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/exception/CommentIsDeletedException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/exception/CommentIsDeletedException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.domain.comment.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class CommentIsDeletedException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.COMMENT_IS_DELETED;
+
+    public CommentIsDeletedException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/exception/CommentNotExistsException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/exception/CommentNotExistsException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.domain.comment.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class CommentNotExistsException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.COMMENT_NOT_EXISTS;
+
+    public CommentNotExistsException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,14 @@
 package dormitoryfamily.doomz.domain.comment.repository;
 
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(attributePaths = "replyComments", type = EntityGraph.EntityGraphType.FETCH)
+    List<Comment> findAllByArticleIdOrderByCreatedAtAsc(Long articleId);
+
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package dormitoryfamily.doomz.domain.comment.repository;
+
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -1,0 +1,38 @@
+package dormitoryfamily.doomz.domain.comment.service;
+
+import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.article.repository.ArticleRepository;
+import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
+import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
+import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+    private final ArticleRepository articleRepository;
+    private final CommentRepository commentRepository;
+
+    public CreateCommentResponseDto save(Long articleId, Member member, CreateCommentRequestDto requestDto) {
+        Article article = getArticleById(articleId);
+        Comment comment = CreateCommentRequestDto.toEntity(member, article, requestDto);
+        commentRepository.save(comment);
+        //댓글 수 증가 로직 추가 예정
+        //알람 로직 추가 예정
+        return CreateCommentResponseDto.fromEntity(comment);
+    }
+
+    private Article getArticleById(Long articleId){
+        return articleRepository.findById(articleId)
+                .orElseThrow(ArticleNotExistsException::new);
+    }
+
+}
+

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
 import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
 import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import jakarta.transaction.Transactional;
@@ -29,9 +30,21 @@ public class CommentService {
         return CreateCommentResponseDto.fromEntity(comment);
     }
 
+    public void removeComment(Member member, Long commentId) {
+        //작성자 확인 코드 추가 예정
+        Comment comment = getCommentById(commentId);
+        //댓글 수 감소 로직 추가 예정
+        commentRepository.delete(comment);
+    }
+
     private Article getArticleById(Long articleId){
         return articleRepository.findById(articleId)
                 .orElseThrow(ArticleNotExistsException::new);
+    }
+
+    private Comment getCommentById(Long commentId){
+        return commentRepository.findById(commentId)
+                .orElseThrow(CommentNotExistsException::new);
     }
 
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -23,7 +23,7 @@ public class CommentService {
 
     public CreateCommentResponseDto saveComment(Long articleId, Member member, CreateCommentRequestDto requestDto) {
         Article article = getArticleById(articleId);
-        Comment comment = CreateCommentRequestDto.toComment(member, article, requestDto);
+        Comment comment = CreateCommentRequestDto.toEntity(member, article, requestDto);
         Comment savedComment = commentRepository.save(comment);
         //댓글 수 증가 로직 추가 예정
         //알람 로직 추가 예정
@@ -35,13 +35,6 @@ public class CommentService {
         Comment comment = getCommentById(commentId);
         //댓글 수 감소 로직 추가 예정
         commentRepository.delete(comment);
-    }
-
-    public CreateCommentResponseDto saveChildComment(Member member, Long parentCommentId, CreateCommentRequestDto requestDto) {
-        Comment parentComment = getCommentById(parentCommentId);
-        Comment childComment = CreateCommentRequestDto.toChildComment(member, parentComment, requestDto);
-        Comment savedChildComment = commentRepository.save(childComment);
-        return CreateCommentResponseDto.fromEntity(savedChildComment);
     }
 
     private Article getArticleById(Long articleId){

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -12,11 +12,13 @@ import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 
+import dormitoryfamily.doomz.domain.member.exception.InvalidMemberAccessException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
@@ -52,6 +54,7 @@ public class CommentService {
 
     public void removeComment(Member member, Long commentId) {
         Comment comment = getCommentById(commentId);
+        isWriter(member, comment.getMember());
         if (hasReplyComment(comment)) {
             comment.markAsDeleted();
         } else {
@@ -63,6 +66,12 @@ public class CommentService {
     public void decideCommentDeletion(Comment comment){;
         if(comment.isDeleted()&&hasReplyComment(comment)){
             commentRepository.delete(comment);
+        }
+    }
+
+    private void isWriter(Member loginMember, Member writer) {
+        if (!Objects.equals(loginMember.getId(), writer.getId())) {
+            throw new InvalidMemberAccessException();
         }
     }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -21,13 +21,13 @@ public class CommentService {
     private final ArticleRepository articleRepository;
     private final CommentRepository commentRepository;
 
-    public CreateCommentResponseDto save(Long articleId, Member member, CreateCommentRequestDto requestDto) {
+    public CreateCommentResponseDto saveComment(Long articleId, Member member, CreateCommentRequestDto requestDto) {
         Article article = getArticleById(articleId);
-        Comment comment = CreateCommentRequestDto.toEntity(member, article, requestDto);
-        commentRepository.save(comment);
+        Comment comment = CreateCommentRequestDto.toComment(member, article, requestDto);
+        Comment savedComment = commentRepository.save(comment);
         //댓글 수 증가 로직 추가 예정
         //알람 로직 추가 예정
-        return CreateCommentResponseDto.fromEntity(comment);
+        return CreateCommentResponseDto.fromEntity(savedComment);
     }
 
     public void removeComment(Member member, Long commentId) {
@@ -35,6 +35,13 @@ public class CommentService {
         Comment comment = getCommentById(commentId);
         //댓글 수 감소 로직 추가 예정
         commentRepository.delete(comment);
+    }
+
+    public CreateCommentResponseDto saveChildComment(Member member, Long parentCommentId, CreateCommentRequestDto requestDto) {
+        Comment parentComment = getCommentById(parentCommentId);
+        Comment childComment = CreateCommentRequestDto.toChildComment(member, parentComment, requestDto);
+        Comment savedChildComment = commentRepository.save(childComment);
+        return CreateCommentResponseDto.fromEntity(savedChildComment);
     }
 
     private Article getArticleById(Long articleId){
@@ -46,6 +53,5 @@ public class CommentService {
         return commentRepository.findById(commentId)
                 .orElseThrow(CommentNotExistsException::new);
     }
-
 }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -9,9 +9,12 @@ import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.member.exception.InvalidMemberAccessException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -24,21 +27,19 @@ public class CommentService {
     public CreateCommentResponseDto saveComment(Long articleId, Member member, CreateCommentRequestDto requestDto) {
         Article article = getArticleById(articleId);
         Comment comment = CreateCommentRequestDto.toEntity(member, article, requestDto);
-        Comment savedComment = commentRepository.save(comment);
-        //댓글 수 증가 로직 추가 예정
-        //알람 로직 추가 예정
-        return CreateCommentResponseDto.fromEntity(savedComment);
+        commentRepository.save(comment);
+        article.increaseCommentCount();
+        return CreateCommentResponseDto.fromEntity(comment);
     }
 
     public void removeComment(Member member, Long commentId) {
-        //작성자 확인 및 댓글수 감소 로직 추가 예정
         Comment comment = getCommentById(commentId);
-
         if (hasReplyComment(comment)) {
             comment.markAsDeleted();
         } else {
             commentRepository.delete(comment);
         }
+        comment.getArticle().decreaseCommentCount();
     }
 
     public void decideCommentDeletion(Comment comment){;

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -31,10 +31,24 @@ public class CommentService {
     }
 
     public void removeComment(Member member, Long commentId) {
-        //작성자 확인 코드 추가 예정
+        //작성자 확인 및 댓글수 감소 로직 추가 예정
         Comment comment = getCommentById(commentId);
-        //댓글 수 감소 로직 추가 예정
-        commentRepository.delete(comment);
+
+        if (hasReplyComment(comment)) {
+            comment.markAsDeleted();
+        } else {
+            commentRepository.delete(comment);
+        }
+    }
+
+    public void decideCommentDeletion(Comment comment){;
+        if(comment.isDeleted()&&hasReplyComment(comment)){
+            commentRepository.delete(comment);
+        }
+    }
+
+    private boolean hasReplyComment(Comment comment) {
+        return comment.getReplyComments().stream().anyMatch(reply -> true);
     }
 
     private Article getArticleById(Long articleId){

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -4,17 +4,22 @@ import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.article.repository.ArticleRepository;
 import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
 import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
+import dormitoryfamily.doomz.domain.comment.dto.response.CommentListResponseDto;
+import dormitoryfamily.doomz.domain.comment.dto.response.CommentResponseDto;
 import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.member.entity.Member;
-import dormitoryfamily.doomz.domain.member.exception.InvalidMemberAccessException;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +35,19 @@ public class CommentService {
         commentRepository.save(comment);
         article.increaseCommentCount();
         return CreateCommentResponseDto.fromEntity(comment);
+    }
+
+    public CommentListResponseDto getCommentList(Long articleId, Member member) {
+
+        Article article = getArticleById(articleId);
+
+        List<Comment> comments = commentRepository.findAllByArticleIdOrderByCreatedAtAsc(articleId);
+
+        List<CommentResponseDto> commentResponseDto = comments.stream()
+                .map(comment -> CommentResponseDto.fromEntity(member, comment))
+                .collect(toList());
+
+        return CommentListResponseDto.toDto(article.getCommentCount(), commentResponseDto);
     }
 
     public void removeComment(Member member, Long commentId) {

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -13,6 +13,8 @@ import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 
 import dormitoryfamily.doomz.domain.member.exception.InvalidMemberAccessException;
+import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+import dormitoryfamily.doomz.domain.replyComment.repository.ReplyCommentRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,7 @@ public class CommentService {
 
     private final ArticleRepository articleRepository;
     private final CommentRepository commentRepository;
+    private final ReplyCommentRepository replyCommentRepository;
 
     public CreateCommentResponseDto saveComment(Long articleId, Member loginMember, CreateCommentRequestDto requestDto) {
         Article article = getArticleById(articleId);
@@ -51,7 +54,7 @@ public class CommentService {
     public void removeComment(Member loginMember, Long commentId) {
         Comment comment = getCommentById(commentId);
         isWriter(loginMember, comment.getMember());
-        if (hasReplyComment(comment)) {
+        if (hasReplyComment(comment.getId())) {
             comment.markAsDeleted();
         } else {
             commentRepository.delete(comment);
@@ -60,7 +63,7 @@ public class CommentService {
     }
 
     public void decideCommentDeletion(Comment comment){;
-        if(comment.isDeleted()&&!hasReplyComment(comment)){
+        if(comment.isDeleted()&&!hasReplyComment(comment.getId())){
             commentRepository.delete(comment);
         }
     }
@@ -71,8 +74,8 @@ public class CommentService {
         }
     }
 
-    private boolean hasReplyComment(Comment comment) {
-        return comment.getReplyComments().stream().anyMatch(reply -> true);
+    public boolean hasReplyComment(Long commentId) {
+        return replyCommentRepository.findFirstByCommentId(commentId).isPresent();
     }
 
     private Article getArticleById(Long articleId){

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
@@ -33,5 +33,16 @@ public class ReplyCommentController {
         return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
     }
 
+    @DeleteMapping("/replyComments/{replyCommentId}")
+    public ResponseEntity<ResponseDto<Void>> deleteComment(
+            @PathVariable Long replyCommentId
+    ) {
+        // 삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        replyCommentService.removeReplyComment(member, replyCommentId);
+        return ResponseEntity.ok(ResponseDto.ok());
+    }
 
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
@@ -1,0 +1,37 @@
+package dormitoryfamily.doomz.domain.replyComment.controller;
+
+
+import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
+import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
+import dormitoryfamily.doomz.domain.comment.service.CommentService;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentRequestDto;
+import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;
+import dormitoryfamily.doomz.domain.replyComment.service.ReplyCommentService;
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ReplyCommentController {
+
+    private final ReplyCommentService replyCommentService;
+
+    @PostMapping("/comments/{commentId}/replyComments")
+    public ResponseEntity<ResponseDto<CreateReplyCommentResponseDto>> saveReplyComment(
+            @PathVariable Long commentId,
+            @RequestBody CreateReplyCommentRequestDto requestDto
+    ) {
+        // 삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        CreateReplyCommentResponseDto responseDto = replyCommentService.saveReplyComment(member, commentId, requestDto);
+        return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
+    }
+
+
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
@@ -1,9 +1,5 @@
 package dormitoryfamily.doomz.domain.replyComment.controller;
 
-
-import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
-import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
-import dormitoryfamily.doomz.domain.comment.service.CommentService;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentRequestDto;
 import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentControllerAdvice.java
@@ -1,0 +1,18 @@
+package dormitoryfamily.doomz.domain.replyComment.controller;
+
+import dormitoryfamily.doomz.domain.replyComment.exception.ReplyCommentNotExistsException;
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+public class ReplyCommentControllerAdvice {
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleReplyCommentNotExistsException(ReplyCommentNotExistsException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/request/CreateReplyCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/request/CreateReplyCommentRequestDto.java
@@ -1,0 +1,20 @@
+package dormitoryfamily.doomz.domain.replyComment.dto.request;
+
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateReplyCommentRequestDto(
+        @NotNull(message = "대댓글 내용은 null일 수 없습니다.")
+        String content
+){
+    public static ReplyComment toEntity(Member member, Comment comment, CreateReplyCommentRequestDto requestDto){
+        return ReplyComment.builder()
+                .member(member)
+                .comment(comment)
+                .content(requestDto.content)
+                .build();
+    }
+}
+

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/CreateReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/CreateReplyCommentResponseDto.java
@@ -1,0 +1,11 @@
+package dormitoryfamily.doomz.domain.replyComment.dto.response;
+
+import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+
+public record CreateReplyCommentResponseDto(
+    Long replyCommentId
+) {
+    public static CreateReplyCommentResponseDto fromEntity(ReplyComment replyComment) {
+        return new CreateReplyCommentResponseDto(replyComment.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -1,10 +1,12 @@
 package dormitoryfamily.doomz.domain.replyComment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public record ReplyCommentResponseDto (
         Long replyCommentId,
@@ -16,7 +18,7 @@ public record ReplyCommentResponseDto (
         String content,
         boolean isWriter
 ) {
-        public static ReplyCommentResponseDto fromEntity(Member member, ReplyComment replyComment) {
+        public static ReplyCommentResponseDto fromEntity(Member loginMember, Article article, ReplyComment replyComment) {
                 return new ReplyCommentResponseDto(
                         replyComment.getId(),
                         replyComment.getMember().getId(),
@@ -24,8 +26,12 @@ public record ReplyCommentResponseDto (
                         replyComment.getMember().getNickname(),
                         replyComment.getCreatedAt(),
                         replyComment.getContent(),
-                        false//추후 수정
+                        isArticleWriter(loginMember, article.getMember())
                 );
+        }
+
+        private static boolean isArticleWriter(Member loginMember, Member articleWriter) {
+                return Objects.equals(loginMember.getId(), articleWriter.getId());
         }
 
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -1,0 +1,34 @@
+package dormitoryfamily.doomz.domain.replyComment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+
+import java.time.LocalDateTime;
+
+public record ReplyCommentResponseDto (
+        Long replyCommentId,
+        Long memberId,
+        String profileUrl,
+        String nickname,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
+        LocalDateTime createdAt,
+        String content,
+        boolean isWriter
+) {
+        public static ReplyCommentResponseDto fromEntity(Member member, ReplyComment replyComment) {
+                return new ReplyCommentResponseDto(
+                        replyComment.getId(),
+                        member.getId(),
+                        member.getProfileUrl(),
+                        member.getNickname(),
+                        replyComment.getCreatedAt(),
+                        replyComment.getContent(),
+                        false//추후 수정
+                );
+        }
+
+}
+
+
+

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -19,9 +19,9 @@ public record ReplyCommentResponseDto (
         public static ReplyCommentResponseDto fromEntity(Member member, ReplyComment replyComment) {
                 return new ReplyCommentResponseDto(
                         replyComment.getId(),
-                        member.getId(),
-                        member.getProfileUrl(),
-                        member.getNickname(),
+                        replyComment.getMember().getId(),
+                        replyComment.getMember().getProfileUrl(),
+                        replyComment.getMember().getNickname(),
                         replyComment.getCreatedAt(),
                         replyComment.getContent(),
                         false//추후 수정

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/entity/ReplyComment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/entity/ReplyComment.java
@@ -1,8 +1,8 @@
-package dormitoryfamily.doomz.domain.comment.entity;
+package dormitoryfamily.doomz.domain.replyComment.entity;
 
 import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;
-import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 import dormitoryfamily.doomz.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,25 +10,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "comment")
-public class Comment extends BaseTimeEntity {
+@Table(name = "reply_comment")
+public class ReplyComment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id")
+    @Column(name = "reply_comment_id")
     private Long id;
-
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "article_id")
-    private Article article;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
@@ -37,17 +30,15 @@ public class Comment extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    @OneToMany(mappedBy = "comment")
-    private List<ReplyComment> replyComments  = new ArrayList<>();
-
-    private boolean isDeleted;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
 
     @Builder
-    public Comment(Article article, Member member, String content, boolean isDeleted) {
-        this.article = article;
+    public ReplyComment(Article article, Member member, Comment comment, String content) {
         this.member = member;
+        this.comment = comment;
         this.content = content;
-        this.isDeleted = isDeleted;
     }
 
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/exception/ReplyCommentNotExistsException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/exception/ReplyCommentNotExistsException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.domain.replyComment.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class ReplyCommentNotExistsException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.REPLY_COMMENT_NOT_EXISTS;
+
+    public ReplyCommentNotExistsException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
@@ -3,5 +3,9 @@ package dormitoryfamily.doomz.domain.replyComment.repository;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long> {
+
+    Optional<ReplyComment> findFirstByCommentId(Long commentId);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
@@ -1,0 +1,7 @@
+package dormitoryfamily.doomz.domain.replyComment.repository;
+
+import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long> {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -1,0 +1,40 @@
+package dormitoryfamily.doomz.domain.replyComment.service;
+
+import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
+import dormitoryfamily.doomz.domain.article.repository.ArticleRepository;
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
+import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentRequestDto;
+import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;
+import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+import dormitoryfamily.doomz.domain.replyComment.repository.ReplyCommentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReplyCommentService {
+
+    private final CommentRepository commentRepository;
+    private final ReplyCommentRepository replyCommentRepository;
+
+    public CreateReplyCommentResponseDto saveReplyComment(Member member, Long commentId, CreateReplyCommentRequestDto requestDto) {
+        Comment comment = getCommentById(commentId);
+        ReplyComment replyComment = CreateReplyCommentRequestDto.toEntity(member, comment, requestDto);
+        ReplyComment savedReplyComment = replyCommentRepository.save(replyComment);
+        return CreateReplyCommentResponseDto.fromEntity(savedReplyComment);
+    }
+
+    private Comment getCommentById(Long commentId){
+        return commentRepository.findById(commentId)
+                .orElseThrow(CommentNotExistsException::new);
+    }
+
+
+}
+

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -1,10 +1,7 @@
 package dormitoryfamily.doomz.domain.replyComment.service;
 
-import dormitoryfamily.doomz.domain.article.entity.Article;
-import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
-import dormitoryfamily.doomz.domain.article.repository.ArticleRepository;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
-import dormitoryfamily.doomz.domain.comment.exception.CommentDeletedException;
+import dormitoryfamily.doomz.domain.comment.exception.CommentIsDeletedException;
 import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.comment.service.CommentService;
@@ -29,6 +26,7 @@ public class ReplyCommentService {
 
     public CreateReplyCommentResponseDto saveReplyComment(Member member, Long commentId, CreateReplyCommentRequestDto requestDto) {
         Comment comment = getCommentById(commentId);
+        checkCommentIsDeleted(comment);
         ReplyComment replyComment = CreateReplyCommentRequestDto.toEntity(member, comment, requestDto);
         ReplyComment savedReplyComment = replyCommentRepository.save(replyComment);
         return CreateReplyCommentResponseDto.fromEntity(savedReplyComment);
@@ -37,6 +35,12 @@ public class ReplyCommentService {
     private Comment getCommentById(Long commentId){
         return commentRepository.findById(commentId)
                 .orElseThrow(CommentNotExistsException::new);
+    }
+
+    private void checkCommentIsDeleted(Comment comment) {
+        if (comment.isDeleted()) {
+            throw new CommentIsDeletedException();
+        }
     }
 
     public void removeReplyComment(Member member, Long replyCommentId) {

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -4,8 +4,10 @@ import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.article.exception.ArticleNotExistsException;
 import dormitoryfamily.doomz.domain.article.repository.ArticleRepository;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.comment.exception.CommentDeletedException;
 import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
+import dormitoryfamily.doomz.domain.comment.service.CommentService;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentRequestDto;
 import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;
@@ -23,6 +25,7 @@ public class ReplyCommentService {
 
     private final CommentRepository commentRepository;
     private final ReplyCommentRepository replyCommentRepository;
+    private final CommentService commentService;
 
     public CreateReplyCommentResponseDto saveReplyComment(Member member, Long commentId, CreateReplyCommentRequestDto requestDto) {
         Comment comment = getCommentById(commentId);
@@ -40,6 +43,7 @@ public class ReplyCommentService {
         //작성자 확인 및 대댓글 수 감소 로직 추가 예정
         ReplyComment replyComment = getReplyCommentById(replyCommentId);
         replyCommentRepository.delete(replyComment);
+        commentService.decideCommentDeletion(replyComment.getComment());
     }
 
     private ReplyComment getReplyCommentById(Long replyCommentId){

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -6,6 +6,7 @@ import dormitoryfamily.doomz.domain.comment.exception.CommentNotExistsException;
 import dormitoryfamily.doomz.domain.comment.repository.CommentRepository;
 import dormitoryfamily.doomz.domain.comment.service.CommentService;
 import dormitoryfamily.doomz.domain.member.entity.Member;
+import dormitoryfamily.doomz.domain.member.exception.InvalidMemberAccessException;
 import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentRequestDto;
 import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
@@ -14,6 +15,8 @@ import dormitoryfamily.doomz.domain.replyComment.repository.ReplyCommentReposito
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -46,6 +49,7 @@ public class ReplyCommentService {
 
     public void removeReplyComment(Member member, Long replyCommentId) {
         ReplyComment replyComment = getReplyCommentById(replyCommentId);
+        isWriter(member, replyComment.getMember());
         replyCommentRepository.delete(replyComment);
         commentService.decideCommentDeletion(replyComment.getComment());
         replyComment.getComment().getArticle().decreaseCommentCount();
@@ -54,6 +58,12 @@ public class ReplyCommentService {
     private ReplyComment getReplyCommentById(Long replyCommentId){
         return replyCommentRepository.findById(replyCommentId)
                 .orElseThrow(ReplyCommentNotExistsException::new);
+    }
+
+    private void isWriter(Member loginMember, Member writer) {
+        if (!Objects.equals(loginMember.getId(), writer.getId())) {
+            throw new InvalidMemberAccessException();
+        }
     }
 }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -10,6 +10,7 @@ import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentRequestDto;
 import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
+import dormitoryfamily.doomz.domain.replyComment.exception.ReplyCommentNotExistsException;
 import dormitoryfamily.doomz.domain.replyComment.repository.ReplyCommentRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,15 @@ public class ReplyCommentService {
                 .orElseThrow(CommentNotExistsException::new);
     }
 
+    public void removeReplyComment(Member member, Long replyCommentId) {
+        //작성자 확인 및 대댓글 수 감소 로직 추가 예정
+        ReplyComment replyComment = getReplyCommentById(replyCommentId);
+        replyCommentRepository.delete(replyComment);
+    }
 
+    private ReplyComment getReplyCommentById(Long replyCommentId){
+        return replyCommentRepository.findById(replyCommentId)
+                .orElseThrow(ReplyCommentNotExistsException::new);
+    }
 }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -27,10 +27,10 @@ public class ReplyCommentService {
     private final ReplyCommentRepository replyCommentRepository;
     private final CommentService commentService;
 
-    public CreateReplyCommentResponseDto saveReplyComment(Member member, Long commentId, CreateReplyCommentRequestDto requestDto) {
+    public CreateReplyCommentResponseDto saveReplyComment(Member loginMember, Long commentId, CreateReplyCommentRequestDto requestDto) {
         Comment comment = getCommentById(commentId);
         checkCommentIsDeleted(comment);
-        ReplyComment replyComment = CreateReplyCommentRequestDto.toEntity(member, comment, requestDto);
+        ReplyComment replyComment = CreateReplyCommentRequestDto.toEntity(loginMember, comment, requestDto);
         replyCommentRepository.save(replyComment);
         comment.getArticle().increaseCommentCount();
         return CreateReplyCommentResponseDto.fromEntity(replyComment);
@@ -47,12 +47,12 @@ public class ReplyCommentService {
         }
     }
 
-    public void removeReplyComment(Member member, Long replyCommentId) {
+    public void removeReplyComment(Member loginMember, Long replyCommentId) {
         ReplyComment replyComment = getReplyCommentById(replyCommentId);
-        isWriter(member, replyComment.getMember());
+        isWriter(loginMember, replyComment.getMember());
         replyCommentRepository.delete(replyComment);
-        commentService.decideCommentDeletion(replyComment.getComment());
         replyComment.getComment().getArticle().decreaseCommentCount();
+        commentService.decideCommentDeletion(replyComment.getComment());
     }
 
     private ReplyComment getReplyCommentById(Long replyCommentId){

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -28,8 +28,9 @@ public class ReplyCommentService {
         Comment comment = getCommentById(commentId);
         checkCommentIsDeleted(comment);
         ReplyComment replyComment = CreateReplyCommentRequestDto.toEntity(member, comment, requestDto);
-        ReplyComment savedReplyComment = replyCommentRepository.save(replyComment);
-        return CreateReplyCommentResponseDto.fromEntity(savedReplyComment);
+        replyCommentRepository.save(replyComment);
+        comment.getArticle().increaseCommentCount();
+        return CreateReplyCommentResponseDto.fromEntity(replyComment);
     }
 
     private Comment getCommentById(Long commentId){
@@ -44,10 +45,10 @@ public class ReplyCommentService {
     }
 
     public void removeReplyComment(Member member, Long replyCommentId) {
-        //작성자 확인 및 대댓글 수 감소 로직 추가 예정
         ReplyComment replyComment = getReplyCommentById(replyCommentId);
         replyCommentRepository.delete(replyComment);
         commentService.decideCommentDeletion(replyComment.getComment());
+        replyComment.getComment().getArticle().decreaseCommentCount();
     }
 
     private ReplyComment getReplyCommentById(Long replyCommentId){

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
     // Member
     INVALID_MEMBER_ACCESS(HttpStatus.NOT_FOUND, "해당 게시글에 대한 권한이 없습니다."),
 
+    // comment
+    COMMENT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 댓글이 존재하지 않습니다."),
+
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
     INVALID_MEMBER_ACCESS(HttpStatus.NOT_FOUND, "해당 게시글에 대한 권한이 없습니다."),
 
     // comment
-    COMMENT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 댓글이 존재하지 않습니다."),
+    COMMENT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 댓글입니다."),
+
+    //replyComment
+    REPLY_COMMENT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 대댓글입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     // comment
     COMMENT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 댓글입니다."),
+    COMMENT_IS_DELETED(HttpStatus.BAD_REQUEST, "삭제된 댓글입니다."),
 
     //replyComment
     REPLY_COMMENT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 대댓글입니다."),


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)

### - **간략한 설명**
  - 댓글과 대댓글을 조회, 작성, 삭제합니다.

---

## 🛠 주요 작성/변경 사항

### - 댓글 작성

### - 댓글 삭제
- 댓글 삭제 시 대댓글이 존재할 경우 isDeleted를 false로 변경하고, 대댓글이 존재하지 않을 경우 DB에서 삭제됩니다.
<img src="https://github.com/dormitoryFamilies/BE/assets/92261242/be53443d-b756-4929-bed7-ca99a2d7912f" width="70%">

### - 대댓글 작성
- 댓글과 대댓글의 테이블을 분리하였기 때문에 대댓글은 별도의 테이블에 저장됩니다.

### - 대댓글 삭제
- 해당 대댓글이 삭제된 댓글에 달린 유일한 댓글일 경우 댓글도 함께 삭제됩니다.
<img src="https://github.com/dormitoryFamilies/BE/assets/92261242/b80ca1b0-e650-4f0f-a61c-354a04e57709" width="70%">
<img src="https://github.com/dormitoryFamilies/BE/assets/92261242/9cc5ae7d-2253-4f5b-8b00-8a7b713eba52" width="70%">

### - 댓글과 대댓글 조회
- CommentListResponseDto는 CommentResponseDto를 List로 가지고 있고, CommentResponseDto ReplyCommentResponseDto를 List로 가지고 있습니다.

---

## 💡 특이 사항 및 고민사항

### 테이블 설계
* 댓글과 대댓글 테이블 설계에서 댓글 테이블 하나로 셀프 조인을 진행할 지 혹은 댓글과 대댓글 테이블을 따로 설계할 지에 대해 고민했습니다. 
* 처음에는 패키지간 양방향 매핑을 피하고자 하나의 테이블로 셀프 조인을 진행하였습니다.
* 하지만 아래와 같은 이유로 테이블은 분리하였습니다.
1)  댓글과 대댓글의 작성과 삭제 api는 별개이며 셀프조인도 결국 양방향이기 때문에 테이블을 분리하는 것이 더 객체지향적인 설계라고 생각
2) 댓글에는 1depth 대댓글만 달 수 있기 때문에 셀프조인을 필수로 할 필요가 없으며 테이블 분리시 코드가 더 깔끔하게 작성됨

### - 대댓글 삭제
  - 해당 대댓글이 삭제된 댓글에 달린 유일한 댓글일 경우 삭제하는 로직에 대해 고민 중입니다.
  - 기존에는 대댓글 서비스에서 대댓글을 삭제한 후, 댓글 서비스를 호출하여 해당 댓글도 삭제해야하는 지 확인하도록 설계하였습니다.
  - 이 방법 외에 대댓글 서비스에서 해당 댓글의 다른 대댓글이 있는지 확인한 후 댓글 서비스를 호출하는 게 더 좋은 설계인지 혹은 다른 더 좋은 방법이 있는 지에 대해 고민 중입니다.

### - 스프링 시큐리티 적용 전, Member 엔티티 수동 주입
  - 스프링 시큐리티 적용 전까지 각 컨트롤러에 임시로 Member 엔티티를 주입해서 사용합니다.



---

## 🔗 관련 이슈

- **이슈 링크** : #13

---

## 📮 리뷰어에게 전하는 메시지
- 리뷰 부탁드립니다
