### PR TITLE
[Fix] 대댓글이 존재하는 댓글 연속 삭제 가능 오류 

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDt
 import dormitoryfamily.doomz.domain.comment.service.CommentService;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.global.util.ResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +21,7 @@ public class CommentController {
     @PostMapping("/articles/{articleId}/comments")
     public ResponseEntity<ResponseDto<CreateCommentResponseDto>> saveComment(
             @PathVariable Long articleId,
-            @RequestBody CreateCommentRequestDto requestDto
+            @RequestBody @Valid CreateCommentRequestDto requestDto
     ) {
         // 삭제 예정
         Member member = new Member();

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -53,5 +53,4 @@ public class CommentController {
         commentService.removeComment(member, commentId);
         return ResponseEntity.ok(ResponseDto.ok());
     }
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/request/CreateCommentRequestDto.java
@@ -3,13 +3,15 @@ package dormitoryfamily.doomz.domain.comment.dto.request;
 import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record CreateCommentRequestDto (
-        @NotNull(message = "댓글 내용은 null일 수 없습니다.")
+        @NotBlank(message = "댓글 내용은 비어있을 수 없습니다.")
         String content
 ){
-    public static Comment toEntity(Member member, Article article, CreateCommentRequestDto requestDto){
+    public static Comment toEntity(Member member,
+                                   Article article,
+                                   CreateCommentRequestDto requestDto){
         return Comment.builder()
                 .article(article)
                 .member(member)

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -1,7 +1,6 @@
 package dormitoryfamily.doomz.domain.comment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.dto.response.ReplyCommentResponseDto;
@@ -9,7 +8,6 @@ import dormitoryfamily.doomz.domain.replyComment.dto.response.ReplyCommentRespon
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -18,14 +16,16 @@ public record CommentResponseDto (
         Long memberId,
         String profileUrl,
         String nickname,
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
         LocalDateTime createdAt,
+
         String content,
         boolean isWriter,
         boolean isDeleted,
         List<ReplyCommentResponseDto> replyComments
 ){
-    public static CommentResponseDto fromEntity(Member loginMember, Article article, Comment comment){
+    public static CommentResponseDto fromEntity(Member loginMember, Comment comment){
         return new CommentResponseDto(
                 comment.getId(),
                 comment.getMember().getId(),
@@ -36,7 +36,7 @@ public record CommentResponseDto (
                 isArticleWriter(loginMember, comment.getMember()),
                 comment.isDeleted(),
                 comment.getReplyComments().stream()
-                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(loginMember, article, replyComment))
+                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(loginMember, replyComment))
                         .collect(toList())
         );
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/entity/Comment.java
@@ -52,7 +52,6 @@ public class Comment extends BaseTimeEntity {
     }
 
     public void markAsDeleted(){
-        this.isDeleted=true;
+        this.isDeleted = true;
     }
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
@@ -10,5 +10,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = "replyComments", type = EntityGraph.EntityGraphType.FETCH)
     List<Comment> findAllByArticleIdOrderByCreatedAtAsc(Long articleId);
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -62,7 +62,7 @@ public class CommentService {
         comment.getArticle().decreaseCommentCount();
     }
 
-    private void checkAlreadyDeleted(Comment comment){
+    private void checkAlreadyDeleted(Comment comment) {
         if (comment.isDeleted()) {
             throw new CommentIsDeletedException();
         }
@@ -74,18 +74,18 @@ public class CommentService {
         }
     }
 
-    private Article getArticleById(Long articleId){
+    private Article getArticleById(Long articleId) {
         return articleRepository.findById(articleId)
                 .orElseThrow(ArticleNotExistsException::new);
     }
 
-    private Comment getCommentById(Long commentId){
+    private Comment getCommentById(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(CommentNotExistsException::new);
     }
 
-    public void decideCommentDeletion(Comment comment){;
-        if(comment.isDeleted()&&!hasReplyComment(comment.getId())){
+    public void decideCommentDeletion(Comment comment) {
+        if (comment.isDeleted() && !hasReplyComment(comment.getId())) {
             commentRepository.delete(comment);
         }
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -45,7 +45,7 @@ public class CommentService {
         Article article = getArticleById(articleId);
         List<Comment> comments = commentRepository.findAllByArticleIdOrderByCreatedAtAsc(articleId);
         List<CommentResponseDto> commentResponseDto = comments.stream()
-                .map(comment -> CommentResponseDto.fromEntity(loginMember, article, comment))
+                .map(comment -> CommentResponseDto.fromEntity(loginMember, comment))
                 .collect(toList());
         return CommentListResponseDto.toDto(article.getCommentCount(), commentResponseDto);
     }
@@ -91,7 +91,7 @@ public class CommentService {
     }
 
     private boolean hasReplyComment(Long commentId) {
-        return replyCommentRepository.findFirstByCommentId(commentId).isPresent();
+        return replyCommentRepository.existsByCommentId(commentId);
     }
 }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
@@ -40,5 +40,4 @@ public class ReplyCommentController {
         replyCommentService.removeReplyComment(member, replyCommentId);
         return ResponseEntity.ok(ResponseDto.ok());
     }
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentController.java
@@ -5,6 +5,7 @@ import dormitoryfamily.doomz.domain.replyComment.dto.request.CreateReplyCommentR
 import dormitoryfamily.doomz.domain.replyComment.dto.response.CreateReplyCommentResponseDto;
 import dormitoryfamily.doomz.domain.replyComment.service.ReplyCommentService;
 import dormitoryfamily.doomz.global.util.ResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,7 +20,7 @@ public class ReplyCommentController {
     @PostMapping("/comments/{commentId}/replyComments")
     public ResponseEntity<ResponseDto<CreateReplyCommentResponseDto>> saveReplyComment(
             @PathVariable Long commentId,
-            @RequestBody CreateReplyCommentRequestDto requestDto
+            @RequestBody @Valid CreateReplyCommentRequestDto requestDto
     ) {
         // 삭제 예정
         Member member = new Member();

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/controller/ReplyCommentControllerAdvice.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 public class ReplyCommentControllerAdvice {
+
     @ExceptionHandler
     public ResponseEntity<ResponseDto<Void>> handleReplyCommentNotExistsException(ReplyCommentNotExistsException e) {
         HttpStatus status = e.getErrorCode().getHttpStatus();

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/request/CreateReplyCommentRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/request/CreateReplyCommentRequestDto.java
@@ -3,13 +3,15 @@ package dormitoryfamily.doomz.domain.replyComment.dto.request;
 import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record CreateReplyCommentRequestDto(
-        @NotNull(message = "대댓글 내용은 null일 수 없습니다.")
+        @NotBlank(message = "대댓글 내용은 비어있을 수 없습니다.")
         String content
 ){
-    public static ReplyComment toEntity(Member member, Comment comment, CreateReplyCommentRequestDto requestDto){
+    public static ReplyComment toEntity(Member member,
+                                        Comment comment,
+                                        CreateReplyCommentRequestDto requestDto){
         return ReplyComment.builder()
                 .member(member)
                 .comment(comment)

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -1,7 +1,6 @@
 package dormitoryfamily.doomz.domain.replyComment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 
@@ -13,12 +12,14 @@ public record ReplyCommentResponseDto (
         Long memberId,
         String profileUrl,
         String nickname,
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
         LocalDateTime createdAt,
+
         String content,
         boolean isWriter
 ) {
-        public static ReplyCommentResponseDto fromEntity(Member loginMember, Article article, ReplyComment replyComment) {
+        public static ReplyCommentResponseDto fromEntity(Member loginMember, ReplyComment replyComment) {
                 return new ReplyCommentResponseDto(
                         replyComment.getId(),
                         replyComment.getMember().getId(),
@@ -26,14 +27,13 @@ public record ReplyCommentResponseDto (
                         replyComment.getMember().getNickname(),
                         replyComment.getCreatedAt(),
                         replyComment.getContent(),
-                        isArticleWriter(loginMember, article.getMember())
+                        isArticleWriter(loginMember,replyComment.getComment().getMember())
                 );
         }
 
         private static boolean isArticleWriter(Member loginMember, Member articleWriter) {
                 return Objects.equals(loginMember.getId(), articleWriter.getId());
         }
-
 }
 
 

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -7,7 +7,7 @@ import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-public record ReplyCommentResponseDto (
+public record ReplyCommentResponseDto(
         Long replyCommentId,
         Long memberId,
         String profileUrl,
@@ -19,21 +19,21 @@ public record ReplyCommentResponseDto (
         String content,
         boolean isWriter
 ) {
-        public static ReplyCommentResponseDto fromEntity(Member loginMember, ReplyComment replyComment) {
-                return new ReplyCommentResponseDto(
-                        replyComment.getId(),
-                        replyComment.getMember().getId(),
-                        replyComment.getMember().getProfileUrl(),
-                        replyComment.getMember().getNickname(),
-                        replyComment.getCreatedAt(),
-                        replyComment.getContent(),
-                        isArticleWriter(loginMember,replyComment.getComment().getMember())
-                );
-        }
+    public static ReplyCommentResponseDto fromEntity(Member loginMember, ReplyComment replyComment) {
+        return new ReplyCommentResponseDto(
+                replyComment.getId(),
+                replyComment.getMember().getId(),
+                replyComment.getMember().getProfileUrl(),
+                replyComment.getMember().getNickname(),
+                replyComment.getCreatedAt(),
+                replyComment.getContent(),
+                isArticleWriter(loginMember, replyComment.getComment().getMember())
+        );
+    }
 
-        private static boolean isArticleWriter(Member loginMember, Member articleWriter) {
-                return Objects.equals(loginMember.getId(), articleWriter.getId());
-        }
+    private static boolean isArticleWriter(Member loginMember, Member articleWriter) {
+        return Objects.equals(loginMember.getId(), articleWriter.getId());
+    }
 }
 
 

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/entity/ReplyComment.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/entity/ReplyComment.java
@@ -35,10 +35,9 @@ public class ReplyComment extends BaseTimeEntity {
     private Comment comment;
 
     @Builder
-    public ReplyComment(Article article, Member member, Comment comment, String content) {
+    public ReplyComment(Member member, Comment comment, String content) {
         this.member = member;
         this.comment = comment;
         this.content = content;
     }
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
@@ -3,9 +3,7 @@ package dormitoryfamily.doomz.domain.replyComment.repository;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long> {
 
-    Optional<ReplyComment> findFirstByCommentId(Long commentId);
+    boolean existsByCommentId(Long commentId);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/service/ReplyCommentService.java
@@ -27,7 +27,9 @@ public class ReplyCommentService {
     private final ReplyCommentRepository replyCommentRepository;
     private final CommentService commentService;
 
-    public CreateReplyCommentResponseDto saveReplyComment(Member loginMember, Long commentId, CreateReplyCommentRequestDto requestDto) {
+    public CreateReplyCommentResponseDto saveReplyComment(Member loginMember,
+                                                          Long commentId,
+                                                          CreateReplyCommentRequestDto requestDto) {
         Comment comment = getCommentById(commentId);
         checkCommentIsDeleted(comment);
         ReplyComment replyComment = CreateReplyCommentRequestDto.toEntity(loginMember, comment, requestDto);


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 버그 수정 (Bug Fix)


### - **간략한 설명**
  - 대댓글이 존재하는 댓글 연속 삭제 가능 오류를 해결하였습니다.

---

## 🛠 주요 작성/변경 사항
  - isDeleted가 true인지 확인하는 코드를 추가했습니다.
 <img src="https://github.com/dormitoryFamilies/BE/assets/92261242/991a72cf-66ef-4801-bc3b-a4d0d40393eb" width="70%">


---

## 💡 특이 사항 및 고민사항
- 추가적으로 댓글과 대댓글 전체 코드를 정리하였습니다.


---

## 🔗 관련 이슈

- **이슈 링크** : #23

---

## 📮 리뷰어에게 전하는 메시지
- 오류 찾아주셔서 감사합니다!
