### PR TITLE
[Refactor] 게시글 검색 시 응답 dto 생성 메서드 사용

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -146,15 +146,8 @@ public class ArticleService {
                                                  Pageable pageable
     ) {
         ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
+
         Slice<Article> articles = articleRepository.searchArticles(dormitoryType, requestDto.q(), pageable);
-
-        List<SimpleArticleResponseDto> articleResponseDtos = articles.stream()
-                .map(article -> {
-                    boolean isWished = checkIfArticleIsWished(article, loginMember);
-                    return SimpleArticleResponseDto.fromEntity(article, isWished);
-                })
-                .toList();
-
-        return ArticleListResponseDto.fromResponseDtos(articles, articleResponseDtos);
+        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
 }


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적
- [x] 리팩토링 (Refactoring)


### - **간략한 설명**
  - 게시글 검색 시 게시글 응답 dto를 생성하는 메서드를 사용하도록 수정 하였습니다.

---

## 🛠 주요 작성/변경 사항
  - 게시글 검색 시 응답 dto를 반환할 때 articleService에 작성된 getSimpleArticleResponseDtos 메서드를 사용도록 하였습니다.