### PR TITLE
[Feauture] 마이페이지 목록 조회 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	// aws S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	//쿼리 파라미터 로그
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/dormitoryfamily/doomz/domain/article/controller/ArticleController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/controller/ArticleController.java
@@ -128,4 +128,18 @@ public class ArticleController {
         ArticleListResponseDto responseDto = articleService.searchArticles(member, dormitoryType, requestDto, pageable);
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
+
+    @GetMapping("/mypage/myArticles")
+    public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
+            @RequestParam String dormitoryType,
+            @RequestParam(required = false) String boardType,
+            Pageable pageable
+    ){
+        //삭제 예정
+        Member member = new Member();
+        member.setId(2L);
+
+        ArticleListResponseDto responseDto = articleService.findMyArticles(member, dormitoryType, boardType, pageable);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
+    }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/article/controller/ArticleController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/controller/ArticleController.java
@@ -137,7 +137,7 @@ public class ArticleController {
     ){
         //삭제 예정
         Member member = new Member();
-        member.setId(2L);
+        member.setId(1L);
 
         ArticleListResponseDto responseDto = articleService.findMyArticles(member, dormitoryType, boardType, pageable);
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));

--- a/src/main/java/dormitoryfamily/doomz/domain/article/controller/ArticleController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/controller/ArticleController.java
@@ -129,7 +129,7 @@ public class ArticleController {
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 
-    @GetMapping("/mypage/myArticles")
+    @GetMapping("/my/articles")
     public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
             @RequestParam String dormitoryType,
             @RequestParam(required = false) String boardType,

--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/SimpleArticleResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/SimpleArticleResponseDto.java
@@ -2,6 +2,7 @@ package dormitoryfamily.doomz.domain.article.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.member.entity.Member;
 
 import java.time.LocalDateTime;
 
@@ -26,6 +27,24 @@ public record SimpleArticleResponseDto(
                         article.getId(),
                         article.getMember().getNickname(),
                         article.getMember().getProfileUrl(),
+                        article.getBoardType().getDescription(),
+                        article.getTitle(),
+                        article.getContent(),
+                        article.getCommentCount(),
+                        article.getWishCount(),
+                        article.getViewCount(),
+                        isWished,
+                        article.getStatus().getDescription(),
+                        article.getCreatedAt(),
+                        article.getThumbnailUrl()
+                );
+        }
+
+        public static SimpleArticleResponseDto fromEntityWithMember(Article article, Member member, boolean isWished) {
+                return new SimpleArticleResponseDto(
+                        article.getId(),
+                        member.getNickname(),
+                        member.getProfileUrl(),
                         article.getBoardType().getDescription(),
                         article.getTitle(),
                         article.getContent(),

--- a/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustom.java
@@ -4,11 +4,14 @@ import dormitoryfamily.doomz.domain.article.dto.request.ArticleRequest;
 import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.article.entity.type.ArticleDormitoryType;
 import dormitoryfamily.doomz.domain.article.entity.type.BoardType;
+import dormitoryfamily.doomz.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ArticleRepositoryCustom {
 
     Slice<Article> findAllByDormitoryTypeAndBoardType(ArticleDormitoryType dormitoryType, BoardType boardType, ArticleRequest request, Pageable pageable);
+
+    Slice<Article> findMyArticleByDormitoryTypeAndBoardType(Member member, ArticleDormitoryType dormitoryType, BoardType boardType, Pageable pageable);
     Slice<Article> searchArticles(ArticleDormitoryType dormitoryType, String keyword, Pageable pageable);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustom.java
@@ -8,10 +8,15 @@ import dormitoryfamily.doomz.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 public interface ArticleRepositoryCustom {
 
     Slice<Article> findAllByDormitoryTypeAndBoardType(ArticleDormitoryType dormitoryType, BoardType boardType, ArticleRequest request, Pageable pageable);
 
     Slice<Article> findMyArticleByDormitoryTypeAndBoardType(Member member, ArticleDormitoryType dormitoryType, BoardType boardType, Pageable pageable);
+
+    Slice<Article> findAllByIdInAndDormitoryTypeAndBoardType(List<Long> articleIds, ArticleDormitoryType dormitoryType, BoardType boardType, Pageable pageable);
+
     Slice<Article> searchArticles(ArticleDormitoryType dormitoryType, String keyword, Pageable pageable);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustomImpl.java
@@ -113,6 +113,26 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
     }
 
     @Override
+    public Slice<Article> findAllByIdInAndDormitoryTypeAndBoardType(List<Long> articleIds,
+                                                                    ArticleDormitoryType dormitoryType,
+                                                                    BoardType boardType,
+                                                                    Pageable pageable) {
+        List<Article> content = queryFactory
+                .selectFrom(article)
+                .where(
+                        article.id.in(articleIds),
+                        dormitoryTypeEq(dormitoryType),
+                        boardTypeEx(boardType)
+                )
+                .orderBy(article.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return createSlice(content, pageable);
+    }
+
+    @Override
     public Slice<Article> searchArticles(ArticleDormitoryType dormitoryType, String keyword, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(article.dormitoryType.eq(dormitoryType))

--- a/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustomImpl.java
@@ -26,7 +26,10 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Article> findAllByDormitoryTypeAndBoardType(ArticleDormitoryType dormitoryType, BoardType boardType, ArticleRequest request, Pageable pageable) {
+    public Slice<Article> findAllByDormitoryTypeAndBoardType(ArticleDormitoryType dormitoryType,
+                                                             BoardType boardType,
+                                                             ArticleRequest request,
+                                                             Pageable pageable) {
 
         List<Article> content = queryFactory
                 .selectFrom(article)
@@ -41,14 +44,7 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        boolean hasNext = false;
-
-        if (content.size() > pageable.getPageSize()) {
-            hasNext = true;
-            content.remove(content.size() - 1);
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
+        return createSlice(content, pageable);
     }
 
     private BooleanExpression dormitoryTypeEq(ArticleDormitoryType dormitoryType) {
@@ -77,6 +73,17 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
         return SortType.fromString(sortType).getOrderSpecifiers();
     }
 
+    private Slice<Article> createSlice(List<Article> content, Pageable pageable) {
+        boolean hasNext = false;
+
+        if (content.size() > pageable.getPageSize()) {
+            hasNext = true;
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
     @Override
     public Slice<Article> findMyArticleByDormitoryTypeAndBoardType(Member member,
                                                                    ArticleDormitoryType dormitoryType,
@@ -95,14 +102,7 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        boolean hasNext = false;
-
-        if (content.size() > pageable.getPageSize()) {
-            hasNext = true;
-            content.remove(content.size() - 1);
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
+        return createSlice(content, pageable);
     }
 
     private BooleanExpression writerEq(Member member) {
@@ -130,13 +130,6 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        boolean hasNext = false;
-
-        if (content.size() > pageable.getPageSize()) {
-            hasNext = true;
-            content.remove(content.size() - 1);
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
+        return createSlice(content, pageable);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -145,16 +145,24 @@ public class ArticleService {
                                                  String articleBoardType,
                                                  Pageable pageable
     ) {
-       ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
+        ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
 
         BoardType boardType = null;
-        if(articleBoardType!=null){
+        if (articleBoardType != null) {
             boardType = BoardType.fromDescription(articleBoardType);
         }
 
         Slice<Article> articles = articleRepository
-                .findMyArticleByDormitoryTypeAndBoardType(loginMember,dormitoryType, boardType, pageable);
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
+                .findMyArticleByDormitoryTypeAndBoardType(loginMember, dormitoryType, boardType, pageable);
+
+        List<SimpleArticleResponseDto> articleResponseDtos = articles.stream()
+                .map(article -> {
+                    boolean isWished = checkIfArticleIsWished(article, loginMember);
+                    return SimpleArticleResponseDto.fromEntityWithMember(article, loginMember, isWished);
+                })
+                .toList();
+
+        return ArticleListResponseDto.fromResponseDtos(articles, articleResponseDtos);
     }
 
     public ArticleListResponseDto searchArticles(Member loginMember,
@@ -167,5 +175,4 @@ public class ArticleService {
         Slice<Article> articles = articleRepository.searchArticles(dormitoryType, requestDto.q(), pageable);
         return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
-
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -140,6 +140,23 @@ public class ArticleService {
         return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
 
+    public ArticleListResponseDto findMyArticles(Member loginMember,
+                                                 String articleDormitoryType,
+                                                 String articleBoardType,
+                                                 Pageable pageable
+    ) {
+       ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
+
+        BoardType boardType = null;
+        if(articleBoardType!=null){
+            boardType = BoardType.fromDescription(articleBoardType);
+        }
+
+        Slice<Article> articles = articleRepository
+                .findMyArticleByDormitoryTypeAndBoardType(loginMember,dormitoryType, boardType, pageable);
+        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
+    }
+
     public ArticleListResponseDto searchArticles(Member loginMember,
                                                  String articleDormitoryType,
                                                  ArticleSearchRequestDto requestDto,
@@ -150,4 +167,5 @@ public class ArticleService {
         Slice<Article> articles = articleRepository.searchArticles(dormitoryType, requestDto.q(), pageable);
         return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
+
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package dormitoryfamily.doomz.domain.comment.controller;
 
+import dormitoryfamily.doomz.domain.article.dto.response.ArticleListResponseDto;
 import dormitoryfamily.doomz.domain.comment.dto.request.CreateCommentRequestDto;
 import dormitoryfamily.doomz.domain.comment.dto.response.CommentListResponseDto;
 import dormitoryfamily.doomz.domain.comment.dto.response.CreateCommentResponseDto;
@@ -8,6 +9,7 @@ import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.global.util.ResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,5 +55,19 @@ public class CommentController {
 
         commentService.removeComment(member, commentId);
         return ResponseEntity.ok(ResponseDto.ok());
+    }
+
+    @GetMapping("/mypage/myComments")
+    public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
+            @RequestParam String dormitoryType,
+            @RequestParam(required = false) String boardType,
+            Pageable pageable
+    ){
+        //삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        ArticleListResponseDto responseDto = commentService.findMyComments(member, dormitoryType, boardType, pageable);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -57,7 +57,7 @@ public class CommentController {
         return ResponseEntity.ok(ResponseDto.ok());
     }
 
-    @GetMapping("/mypage/myComments")
+    @GetMapping("/my/comments")
     public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
             @RequestParam String dormitoryType,
             @RequestParam(required = false) String boardType,

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/repository/CommentRepository.java
@@ -10,4 +10,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = "replyComments", type = EntityGraph.EntityGraphType.FETCH)
     List<Comment> findAllByArticleIdOrderByCreatedAtAsc(Long articleId);
+
+    List<Comment> findAllByMemberId(Long id);
+
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/member/entity/Member.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import dormitoryfamily.doomz.domain.member.entity.type.CollegeType;
 import dormitoryfamily.doomz.domain.member.entity.type.DepartmentType;
 import dormitoryfamily.doomz.domain.member.entity.type.GenderType;
 import dormitoryfamily.doomz.domain.member.entity.type.MemberDormitoryType;
+import dormitoryfamily.doomz.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,7 +15,7 @@ import java.time.LocalDate;
 //setter와 기본생성자 임시 허용
 @Setter
 @NoArgsConstructor
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,13 +36,12 @@ public class Member {
     private MemberDormitoryType dormitoryType;
 
     private LocalDate birthDate;
-    private String phoneNumber;
 
     @Enumerated(EnumType.STRING)
     private GenderType genderType;
 
     private String profileUrl;
-    private String studentCardImage;
+    private String studentCardImageUrl;
 
     public Member(String name,
                   String nickname,
@@ -50,10 +50,9 @@ public class Member {
                   DepartmentType departmentType,
                   MemberDormitoryType dormitoryType,
                   LocalDate birthDate,
-                  String phoneNumber,
                   GenderType genderType,
                   String profileUrl,
-                  String studentCardImage) {
+                  String studentCardImageUrl) {
         this.name = name;
         this.nickname = nickname;
         this.studentNumber = studentNumber;
@@ -61,9 +60,8 @@ public class Member {
         this.departmentType = departmentType;
         this.dormitoryType = dormitoryType;
         this.birthDate = birthDate;
-        this.phoneNumber = phoneNumber;
         this.genderType = genderType;
         this.profileUrl = profileUrl;
-        this.studentCardImage = studentCardImage;
+        this.studentCardImageUrl = studentCardImageUrl;
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/member/entity/type/GenderType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/entity/type/GenderType.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum GenderType {
 
     MALE("남자"),
-    FEMALE("여자");
+    FEMALE("여자"),
+    OTHER("기타");
 
     private final String description;
 

--- a/src/main/java/dormitoryfamily/doomz/domain/member/entity/type/GenderType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/entity/type/GenderType.java
@@ -8,8 +8,7 @@ import lombok.Getter;
 public enum GenderType {
 
     MALE("남자"),
-    FEMALE("여자"),
-    OTHER("기타");
+    FEMALE("여자");
 
     private final String description;
 

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/repository/ReplyCommentRepository.java
@@ -3,7 +3,12 @@ package dormitoryfamily.doomz.domain.replyComment.repository;
 import dormitoryfamily.doomz.domain.replyComment.entity.ReplyComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long> {
 
     boolean existsByCommentId(Long commentId);
+
+    List<ReplyComment> findAllByMemberId(Long id);
+
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/controller/WishController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/controller/WishController.java
@@ -51,7 +51,7 @@ public class WishController {
         return ResponseEntity.ok(ResponseDto.ok());
     }
 
-    @GetMapping("/mypage/articleWishes")
+    @GetMapping("/my/wishes")
     public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
             @RequestParam String dormitoryType,
             Pageable pageable

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/controller/WishController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/controller/WishController.java
@@ -1,21 +1,25 @@
 package dormitoryfamily.doomz.domain.wish.controller;
 
+import dormitoryfamily.doomz.domain.article.dto.response.ArticleListResponseDto;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.domain.wish.dto.WishMemberListResponseDto;
 import dormitoryfamily.doomz.domain.wish.service.WishService;
 import dormitoryfamily.doomz.global.util.ResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/articles/{articleId}/wishes")
+@RequestMapping("/api")
 public class WishController {
 
     private final WishService wishService;
 
-    @PostMapping
+    @PostMapping("/articles/{articleId}/wishes")
     public ResponseEntity<ResponseDto<Void>> saveWish(
             @PathVariable Long articleId
     ){
@@ -27,7 +31,7 @@ public class WishController {
         return ResponseEntity.ok(ResponseDto.created());
     }
 
-    @GetMapping
+    @GetMapping("/articles/{articleId}/wishes")
     public ResponseEntity<ResponseDto<WishMemberListResponseDto>> getWishMemberList(
             @PathVariable Long articleId
     ){
@@ -35,7 +39,7 @@ public class WishController {
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 
-    @DeleteMapping
+    @DeleteMapping("/articles/{articleId}/wishes")
     public ResponseEntity<ResponseDto<Void>> cancelWish(
             @PathVariable Long articleId
     ){
@@ -45,5 +49,18 @@ public class WishController {
 
         wishService.removeWish(member, articleId);
         return ResponseEntity.ok(ResponseDto.ok());
+    }
+
+    @GetMapping("/mypage/articleWishes")
+    public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
+            @RequestParam String dormitoryType,
+            Pageable pageable
+    ){
+        //삭제 예정
+        Member member = new Member();
+        member.setId(1L);
+
+        ArticleListResponseDto responseDto = wishService.findMyArticleWishes(member, dormitoryType, pageable);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/repository/WishRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/repository/WishRepository.java
@@ -13,4 +13,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
     boolean existsByMemberIdAndArticleId(Long memberId, Long articleId);
 
     Optional<Wish> findByMemberIdAndArticleId(Long memberId, Long articleId);
+
+    List<Wish> findWishesByMemberId(Long memberId);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/repository/WishRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/repository/WishRepository.java
@@ -8,13 +8,11 @@ import java.util.Optional;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
-    List<Wish> findByArticleId(Long articleId);
+    List<Wish> findAllByArticleId(Long articleId);
 
     boolean existsByMemberIdAndArticleId(Long memberId, Long articleId);
 
     Optional<Wish> findByMemberIdAndArticleId(Long memberId, Long articleId);
-
-    List<Wish> findWishesByMemberId(Long memberId);
 
     List<Wish> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/repository/WishRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/repository/WishRepository.java
@@ -15,4 +15,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
     Optional<Wish> findByMemberIdAndArticleId(Long memberId, Long articleId);
 
     List<Wish> findWishesByMemberId(Long memberId);
+
+    List<Wish> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/service/WishService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/service/WishService.java
@@ -41,7 +41,7 @@ public class WishService {
 
     public WishMemberListResponseDto getWishMembers(Long articleId){
         getArticleById(articleId);
-        List<Wish> wishes = wishRepository.findByArticleId(articleId);
+        List<Wish> wishes = wishRepository.findAllByArticleId(articleId);
         List<WishMemberResponseDto> wishMemberResponseDtos = wishes.stream()
                 .map(wish -> WishMemberResponseDto.fromMember(wish.getMember())).collect(toList());
         return WishMemberListResponseDto.toDto(wishMemberResponseDtos);
@@ -74,7 +74,7 @@ public class WishService {
 
         ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
 
-        List<Wish> myWishes = wishRepository.findWishesByMemberId(loginmember.getId());
+        List<Wish> myWishes = wishRepository.findAllByMemberId(loginmember.getId());
 
         List<Long> articleIds = myWishes.stream()
                 .map(wish -> wish.getArticle().getId())
@@ -85,8 +85,7 @@ public class WishService {
 
         List<SimpleArticleResponseDto> articleResponseDtos = articles.stream()
                 .map(article -> {
-                    boolean isWished = true;
-                    return SimpleArticleResponseDto.fromEntity(article, isWished);
+                    return SimpleArticleResponseDto.fromEntity(article, true);
                 })
                 .toList();
 


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)
- [x] 리팩토링 (Refactoring)

### - **간략한 설명**
 - 게시판 찜 목록 조회
 - 내가 쓴 게시글 목록 조회
 - 내가 쓴 댓글 목록 조회

---

## 🛠 주요 작성/변경 사항
- 내가 찜한 게시글 목록을 조회합니다.
- 내가 쓴 댓글 목록을 게시판 보드 타입 필터를 포함하여 조회합니다.
- 내가 쓴 댓글의 게시글 목록을 보드 타입 필터 포함하여 조회합니다.

---

## 💡 특이 사항 및 고민사항

### - 게시글 조회 시 찜 여부 확인 메서드 수정
  - 기존에는 게시글 목록을 응답 dto로 반환할 때 게시글 마다 해당 사용자가 찜을 했는 지 여부를 확인했기 때문에, 게시글목록의 개수만큼 해당 쿼리가 조회되었습니다. 따라서 게시글이 10개라면 10번의 쿼리가 날아가도록 되어있었습니다. 
![image](https://github.com/dormitoryFamilies/BE/assets/92261242/4cf01715-ca45-4893-9bd3-f79021dacd29)
![image](https://github.com/dormitoryFamilies/BE/assets/92261242/0526845e-08d2-4346-b5d7-530de8862055)

* 따라서, 이 부분을 하나의 쿼리로 해결하기 위해 내가 찜한 게시글 목록을 미리 조회한 후, 응답 dto를 생성할 때 해당 게시글이 찜 목록에 해당되는 지 확인하도록 수정하였습니다. 
![image](https://github.com/dormitoryFamilies/BE/assets/92261242/4f2bc3fa-db3a-4364-8b52-5a4ab3eca6ea)

###  - Slice&lt;Article&gt; 생성 메서드 분리
* ArticleRepositoryCustomImpl에서 Slice&lt;Article&gt; 을 생성하는 부분이 여러 메서드에서 사용되어 따로 메서드로 분리하였습니다.

### - 게시글 조회 응답 dto 에서 멤버를 매개변수로 받는 메서드 추가 
* 내가 작성한 게시글을 조회하는 경우에는 게시글 작성자가 본인이기 때문에 SimpleArticleResponseDto에서 dto를 생성할 때 article.getMember()를 통해 멤버를 가져와 쿼리를 한 번 더 날리는 것 보다는 멤버를 매개변수로 받아 사용하는 것이 더 효율적이라고 생각하여 fromEntityWithMember 메서드를 생성하였습니다.

### - 쿼리 파라미터 로그 라이브러리 추가
---

## 🔗 관련 이슈

- **이슈 링크** : #38 

---

## 📮 리뷰어에게 전하는 메시지
- 리뷰 부탁드립니다.
