### PR TITLE
[Feature] 게시판 1건 조회 DTO에 작성자 여부 boolean 값 추가

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleResponseDto.java
@@ -22,6 +22,7 @@ public record ArticleResponseDto(
         String content,
         int wishCount,
         boolean isWished,
+        boolean isWriter,
         String status,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -29,7 +30,7 @@ public record ArticleResponseDto(
 
         List<String> imagesUrls
 ) {
-    public static ArticleResponseDto fromEntity(Member loginMember, Article article, boolean isWished, List<ArticleImage> articleImages) {
+    public static ArticleResponseDto fromEntity(Member loginMember, Article article, boolean isWished, boolean isWriter, List<ArticleImage> articleImages) {
         return new ArticleResponseDto(
                 article.getId(),
                 article.getMember().getId(),
@@ -43,6 +44,7 @@ public record ArticleResponseDto(
                 article.getContent(),
                 article.getWishCount(),
                 isWished,
+                isWriter,
                 article.getStatus().getDescription(),
                 article.getCreatedAt(),
                 getArticleImagesUrls(articleImages)

--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -62,9 +62,10 @@ public class ArticleService {
         Article article = getArticleById(articleId);
         List<ArticleImage> articleImages = articleImageRepository.findByArticleId(articleId);
         boolean isWished = checkIfArticleIsWished(article, loginMember);
+        boolean isWriter = isWriter(loginMember, article.getMember());
 
         article.plusViewCount();
-        return ArticleResponseDto.fromEntity(loginMember, article, isWished, articleImages);
+        return ArticleResponseDto.fromEntity(loginMember, article, isWished, isWriter, articleImages);
     }
 
     private Article getArticleById(Long articleId) {
@@ -79,7 +80,9 @@ public class ArticleService {
     public void updateArticle(PrincipalDetails principalDetails, Long articleId, ArticleRequestDto requestDto) {
         Member loginMember = principalDetails.getMember();
         Article article = getArticleById(articleId);
-        isWriter(loginMember, article.getMember());
+        if (!isWriter(loginMember, article.getMember())) {
+            throw new InvalidMemberAccessException();
+        }
 
         articleImageRepository.deleteAllByArticle(article);
         saveArticleImages(article, requestDto);
@@ -87,16 +90,16 @@ public class ArticleService {
         article.updateArticle(requestDto);
     }
 
-    private void isWriter(Member loginMember, Member writer) {
-        if (!Objects.equals(loginMember.getId(), writer.getId())) {
-            throw new InvalidMemberAccessException();
-        }
+    private boolean isWriter(Member loginMember, Member writer) {
+        return Objects.equals(loginMember.getId(), writer.getId());
     }
 
     public void deleteArticle(PrincipalDetails principalDetails, Long articleId) {
         Member loginMember = principalDetails.getMember();
         Article article = getArticleById(articleId);
-        isWriter(loginMember, article.getMember());
+        if (!isWriter(loginMember, article.getMember())) {
+            throw new InvalidMemberAccessException();
+        }
 
         articleRepository.delete(article);
     }
@@ -104,7 +107,9 @@ public class ArticleService {
     public void changeStatus(PrincipalDetails principalDetails, Long articleId, String status) {
         Member loginMember = principalDetails.getMember();
         Article article = getArticleById(articleId);
-        isWriter(loginMember, article.getMember());
+        if (!isWriter(loginMember, article.getMember())) {
+            throw new InvalidMemberAccessException();
+        }
 
         StatusType statusType = StatusType.fromDescription(status);
         article.changeStatus(statusType);


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)

### - **간략한 설명**
  - 게시글을 단 건 조회할시. 로그인한 사용자가 해당 게시글의 작성자인지의 여부를 boolean 값으로 반환하는 변수와 기능을 추가했습니다.

---

## 🛠 주요 작성/변경 사항

### -  ArticleResponseDto에 isWriter 변수 추가
    
![Screen Shot 2024-05-14 at 5 58 32 PM](https://github.com/dormitoryFamilies/BE/assets/85631282/9b9ffb80-6b5f-4814-a0ae-9fd569bcf44c)

---

## 💡 특이 사항 및 고민사항

### - 기존의 isWriter 메소드를 약간 수정하여 재사용
  - 게시글 수정 또는 삭제 메소드에서 사용하던 isWriter 메소드를 약간 수정하여 재사용했습니다. 기존 메소드에선 작성자 id와 로그인 사용자 id가 다를시 예외를 발생시켰던 반면, 수정된 메소드에선 boolean 값을 반환하도록 바꿨습니다.
```java
private boolean isWriter(Member loginMember, Member writer) {
    return Objects.equals(loginMember.getId(), writer.getId());
}
```

  - 따라서 기존 삭제, 업데이트 요청 메소드에서 위 메소드의 반환 값이 `false`인 경우 따로 예외 발생 로직을 추가했습니다.

---

## 🔗 관련 이슈

- **이슈 링크** : #66 

---

## 📮 리뷰어에게 전하는 메시지
- 간단한 로직입니다. 리뷰 부탁드립니다 :)
