### PR TITLE
[Feat] 게시글 삭제시 댓글까지 함께 삭제되는 기능 구현

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/entity/Article.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/entity/Article.java
@@ -5,6 +5,7 @@ import dormitoryfamily.doomz.domain.article.entity.type.ArticleDormitoryType;
 import dormitoryfamily.doomz.domain.article.entity.type.BoardType;
 import dormitoryfamily.doomz.domain.article.entity.type.StatusType;
 import dormitoryfamily.doomz.domain.article.exception.StatusAlreadySetException;
+import dormitoryfamily.doomz.domain.comment.entity.Comment;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import dormitoryfamily.doomz.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -34,6 +35,9 @@ public class Article extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "article", orphanRemoval = true)
     private List<ArticleImage> articleImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "article", orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     @Column(nullable = false)
     private String title;


### PR DESCRIPTION
Article 엔티티에 Comment 엔티티와 양방향 매핑한 뒤, orphanremoval = true 작업 진행

<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)

### - **간략한 설명**
  - 기존 코드는 게시글에 댓글이 작성되어 있으면 해당 게시글을 삭제할 수 없었습니다.
  - 정책상 댓글이 달려 있어도 게시글을 삭제할 수 있어야 했기 때문에 게시글과 댓글을 양방향 매핑 한 뒤, `orphanremoval = true` 옵션을 추가했습니다.

---

## 🛠 주요 작성/변경 사항

### - orphanremoval = true 추가
  - 양방향 매핑 후 `orphanremoval = true` 설정을 함으로써 게시글이 삭제될 때 고아가 된 댓글 정보도 DB에서 함께 삭제가 됩니다.
```java
@OneToMany(mappedBy = "article", orphanRemoval = true)
private List<Comment> comments = new ArrayList<>();
``` 
---

## 🔗 관련 이슈

- **이슈 링크** : #71 

---

## 📮 리뷰어에게 전하는 메시지
- 간단한 코드 추가입니다. 리뷰 부탁드립니다!
