### PR TITLE
[Feature] 게시판 관련 enum 수정

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/request/ArticleRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/request/ArticleRequestDto.java
@@ -44,9 +44,9 @@ public record ArticleRequestDto(
                 .build();
     }
 
-    public static BoardType getBoardType(ArticleRequestDto requestDto){
-        BoardType boardType =BoardType.fromDescription(requestDto.boardType);
-        if(boardType.equals(BoardType.ALL)){
+    public static BoardType getBoardType(ArticleRequestDto requestDto) {
+        BoardType boardType = BoardType.fromDescription(requestDto.boardType);
+        if (boardType.equals(BoardType.ALL)) {
             throw new InvalidBoardTypeException();
         }
         return boardType;

--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/request/ArticleRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/request/ArticleRequestDto.java
@@ -6,6 +6,7 @@ import dormitoryfamily.doomz.domain.article.entity.Article;
 import dormitoryfamily.doomz.domain.article.entity.type.ArticleDormitoryType;
 import dormitoryfamily.doomz.domain.article.entity.type.BoardType;
 import dormitoryfamily.doomz.domain.article.entity.type.StatusType;
+import dormitoryfamily.doomz.domain.article.exception.InvalidBoardTypeException;
 import dormitoryfamily.doomz.domain.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
@@ -38,8 +39,16 @@ public record ArticleRequestDto(
                 .thumbnailUrl(!requestDto.imagesUrls.isEmpty() ? requestDto.imagesUrls.get(0) : null)
                 .status(StatusType.PROGRESS)
                 .dormitoryType(ArticleDormitoryType.fromName(requestDto.dormitoryType))
-                .boardType(BoardType.fromDescription(requestDto.boardType))
+                .boardType(getBoardType(requestDto))
                 .tags(requestDto.tags)
                 .build();
+    }
+
+    public static BoardType getBoardType(ArticleRequestDto requestDto){
+        BoardType boardType =BoardType.fromDescription(requestDto.boardType);
+        if(boardType.equals(BoardType.ALL)){
+            throw new InvalidBoardTypeException();
+        }
+        return boardType;
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/article/entity/type/ArticleDormitoryType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/entity/type/ArticleDormitoryType.java
@@ -8,8 +8,7 @@ public enum ArticleDormitoryType {
 
     MAIN_BUILDING("본관"),
     MALE_DORMITORY("양성재"),
-    FEMALE_DORMITORY("양진재"),
-    COED_DORMITORY("양현재");
+    FEMALE_DORMITORY("양진재");
 
     private final String name;
 

--- a/src/main/java/dormitoryfamily/doomz/domain/article/entity/type/BoardType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/entity/type/BoardType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 public enum BoardType {
 
+    ALL("전체"),
     HELP("도와주세요"),
     TOGETHER("함께해요"),
     SHARE("나눔해요"),

--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -171,7 +171,7 @@ public class ArticleService {
         ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
 
         BoardType boardType = fromDescription(articleBoardType);
-        if(boardType.equals(ALL)){
+        if (boardType.equals(ALL)) {
             boardType = null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -29,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 
+import static dormitoryfamily.doomz.domain.article.entity.type.BoardType.*;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -152,7 +154,7 @@ public class ArticleService {
     ) {
         Member loginMember = principalDetails.getMember();
         ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
-        BoardType boardType = BoardType.fromDescription(articleBoardType);
+        BoardType boardType = fromDescription(articleBoardType);
 
         Slice<Article> articles = articleRepository
                 .findAllByDormitoryTypeAndBoardType(dormitoryType, boardType, request, pageable);
@@ -168,11 +170,9 @@ public class ArticleService {
         Member loginMember = principalDetails.getMember();
         ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
 
-        BoardType boardType;
-        if (articleBoardType.equals("all")) {
+        BoardType boardType = fromDescription(articleBoardType);
+        if(boardType.equals(ALL)){
             boardType = null;
-        } else {
-            boardType = BoardType.fromDescription(articleBoardType);
         }
 
         Slice<Article> articles = articleRepository


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)


### - **간략한 설명**
  - 기숙사 타입 '양현재'는 사용하지 않기로 결정하여 삭제합니다.
  - 게시판 타입에 '전체'를 추가합니다.
---

## 🛠 주요 작성/변경 사항
  ### 게시판 타입에 ALL을 추가
  - "전체" 카테고리의 게시판은 없지만, 모든 게시판을 한 번에 조회하는 경우가 존재합니다.
  - 따라서 기존에는 전체 타입 조회 시 boardType을 "all"로 하드코딩하여 처리했지만, 코드의 일관성과 안정성을 위해 게시판 타입 enum에 ALL타입을 추가했습니다.
  -  대신, 게시글을 등록할 경우에는 "전체"의 카테고리는 존재하지 않기 때문에, 해당 부분은 예외 처리 했습니다.
### 기존 코드
```
 BoardType boardType;
  if(articleBoardType.equals("all")){
      boardType = null;
    }
   else{
       boardType = BoardType.fromDescription(articleBoardType);
    }
```
### 수정된 코드
```
   BoardType boardType = fromDescription(articleBoardType);
   if (boardType.equals(ALL)) {
        boardType = null;
   }
```
---

## 🔗 관련 이슈

- **이슈 링크** : #76 

---

## 📮 리뷰어에게 전하는 메시지
- 리뷰 부탁드립니다.
