### PR TITLE
[Bug] 댓글 작성시 게시글 작성자 여부 확인 오류

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleResponseDto.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 public record ArticleResponseDto(
         Long articleId,
         Long memberId,
-        String nickName,
+        String nickname,
         String profileUrl,
         String memberDormitory,
         String articleDormitory,

--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/SimpleArticleResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/SimpleArticleResponseDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 public record SimpleArticleResponseDto(
         Long articleId,
-        String nickName,
+        String nickname,
         String profileUrl,
         String boardType,
         String title,

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -15,7 +15,7 @@ public record CommentResponseDto (
         Long commentId,
         Long memberId,
         String profileUrl,
-        String nickName,
+        String nickname,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime createdAt,
@@ -33,7 +33,7 @@ public record CommentResponseDto (
                 comment.getMember().getNickname(),
                 comment.getCreatedAt(),
                 comment.getContent(),
-                isArticleWriter(loginMember, comment.getMember()),
+                isArticleWriter(loginMember, comment.getArticle().getMember()),
                 comment.isDeleted(),
                 comment.getReplyComments().stream()
                         .map(replyComment -> ReplyCommentResponseDto.fromEntity(loginMember, replyComment))

--- a/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MyProfileResponseDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 
 
 public record MyProfileResponseDto (
+        Long memberId,
         String name,
         String genderType,
         String nickname,
@@ -22,6 +23,7 @@ public record MyProfileResponseDto (
 ){
     public static MyProfileResponseDto fromEntity(Member member){
         return new MyProfileResponseDto(
+                member.getId(),
                 member.getName(),
                 member.getGenderType().getDescription(),
                 member.getNickname(),

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -27,7 +27,7 @@ public record ReplyCommentResponseDto(
                 replyComment.getMember().getNickname(),
                 replyComment.getCreatedAt(),
                 replyComment.getContent(),
-                isArticleWriter(loginMember, replyComment.getComment().getMember())
+                isArticleWriter(loginMember, replyComment.getComment().getArticle().getMember())
         );
     }
 


### PR DESCRIPTION

## 🎯 목적

- [x] 리팩토링 (Refactoring)
- [x] 버그 수정 (Bug Fix)

### - **간략한 설명**
  - 댓글 조회 시 게시글 작성자 여부에 대한 오류를 수정합니다.

---

## 🛠 주요 작성/변경 사항

- 댓글과 대댓글 조회 response에서 isWriter 변수 값을 로그인한 사용자와 댓글 작성자를 비교하는 코드로 잘못 작성되어, 게시글 작성자와 비교하도록 변경했습니다.
- nickName -> nickname으로 변수명을 변경했습니다.
---


## 🔗 관련 이슈

- **이슈 링크** : #80 
