### PR TITLE
[Feature] 게시판, 댓글 응답에 로그인한 유저 id 정보 추가

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleListResponseDto.java
@@ -1,20 +1,24 @@
 package dormitoryfamily.doomz.domain.article.dto.response;
 
 import dormitoryfamily.doomz.domain.article.entity.Article;
+import dormitoryfamily.doomz.domain.member.entity.Member;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 public record ArticleListResponseDto(
-    int nowPageNumber,
-    boolean isLast,
-    List<SimpleArticleResponseDto> articles
+        long loginMemberId,
+        int nowPageNumber,
+        boolean isLast,
+        List<SimpleArticleResponseDto> articles
 ) {
     public static ArticleListResponseDto fromResponseDtos(
+            Member loginMember,
             Slice<Article> articles,
             List<SimpleArticleResponseDto> articleResponseDtos
     ) {
         return new ArticleListResponseDto(
+                loginMember.getId(),
                 articles.getNumber(),
                 articles.isLast(),
                 articleResponseDtos

--- a/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/dto/response/ArticleResponseDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public record ArticleResponseDto(
+        Long loginMemberId,
         Long articleId,
         Long memberId,
         String nickname,
@@ -32,6 +33,7 @@ public record ArticleResponseDto(
 ) {
     public static ArticleResponseDto fromEntity(Member loginMember, Article article, boolean isWished, boolean isWriter, List<ArticleImage> articleImages) {
         return new ArticleResponseDto(
+                loginMember.getId(),
                 article.getId(),
                 article.getMember().getId(),
                 article.getMember().getNickname(),

--- a/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/service/ArticleService.java
@@ -127,7 +127,7 @@ public class ArticleService {
 
         Slice<Article> articles = articleRepository
                 .findAllByDormitoryTypeAndBoardType(dormitoryType, null, request, pageable);
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
+        return ArticleListResponseDto.fromResponseDtos(loginMember, articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
 
     private List<SimpleArticleResponseDto> getSimpleArticleResponseDtos(Member loginMember, Slice<Article> articles) {
@@ -158,7 +158,7 @@ public class ArticleService {
 
         Slice<Article> articles = articleRepository
                 .findAllByDormitoryTypeAndBoardType(dormitoryType, boardType, request, pageable);
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
+        return ArticleListResponseDto.fromResponseDtos(loginMember, articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
 
     public ArticleListResponseDto findMyArticles(PrincipalDetails principalDetails,
@@ -177,7 +177,7 @@ public class ArticleService {
 
         Slice<Article> articles = articleRepository
                 .findMyArticleByDormitoryTypeAndBoardType(loginMember, dormitoryType, boardType, request, pageable);
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtosWithMember(loginMember, articles));
+        return ArticleListResponseDto.fromResponseDtos(loginMember, articles, getSimpleArticleResponseDtosWithMember(loginMember, articles));
     }
 
     private List<SimpleArticleResponseDto> getSimpleArticleResponseDtosWithMember(Member loginMember, Slice<Article> articles) {
@@ -200,6 +200,6 @@ public class ArticleService {
         ArticleDormitoryType dormitoryType = ArticleDormitoryType.fromName(articleDormitoryType);
 
         Slice<Article> articles = articleRepository.searchArticles(dormitoryType, requestDto.q(), pageable);
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
+        return ArticleListResponseDto.fromResponseDtos(loginMember, articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/controller/CommentController.java
@@ -53,8 +53,8 @@ public class CommentController {
         return ResponseEntity.ok(ResponseDto.ok());
     }
 
-    @GetMapping("/my/dormitories/{dormitoryType}/board-type/{boardType}/comments")
-    public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyArticleWishes(
+    @GetMapping("/my/dormitories/{dormitoryType}/board-types/{boardType}/comments")
+    public ResponseEntity<ResponseDto<ArticleListResponseDto>> findMyComments(
             @PathVariable String dormitoryType,
             @PathVariable String boardType,
             @ModelAttribute ArticleRequest request,

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentListResponseDto.java
@@ -1,12 +1,15 @@
 package dormitoryfamily.doomz.domain.comment.dto.response;
 
+import dormitoryfamily.doomz.domain.member.entity.Member;
+
 import java.util.List;
 
-public record CommentListResponseDto (
-    int totalCount,
-    List<CommentResponseDto> comments
-){
-    public static CommentListResponseDto toDto(int totalCount, List<CommentResponseDto> comments) {
-        return new CommentListResponseDto(totalCount, comments);
+public record CommentListResponseDto(
+        long loginMemberId,
+        int totalCount,
+        List<CommentResponseDto> comments
+) {
+    public static CommentListResponseDto toDto(Member loginMember, int totalCount, List<CommentResponseDto> comments) {
+        return new CommentListResponseDto(loginMember.getId(), totalCount, comments);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -21,7 +21,7 @@ public record CommentResponseDto (
         LocalDateTime createdAt,
 
         String content,
-        boolean isWriter,
+        boolean isArticleWriter,
         boolean isDeleted,
         List<ReplyCommentResponseDto> replyComments
 ){

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -129,7 +129,7 @@ public class CommentService {
         Slice<Article> articles = articleRepository
                 .findAllByIdInAndDormitoryTypeAndBoardType(articleIds, dormitoryType, boardType, request, pageable);
 
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDtos(loginMember, articles));
+        return ArticleListResponseDto.fromResponseDtos(loginMember, articles, getSimpleArticleResponseDtos(loginMember, articles));
     }
 
     private List<Long> getArticleIds(List<Comment> comments, List<ReplyComment> replyComments) {

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -61,7 +61,7 @@ public class CommentService {
         List<CommentResponseDto> commentResponseDto = comments.stream()
                 .map(comment -> CommentResponseDto.fromEntity(loginMember, comment))
                 .collect(toList());
-        return CommentListResponseDto.toDto(article.getCommentCount(), commentResponseDto);
+        return CommentListResponseDto.toDto(loginMember, article.getCommentCount(), commentResponseDto);
     }
 
     public void removeComment(PrincipalDetails principalDetails, Long commentId) {

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -17,7 +17,7 @@ public record ReplyCommentResponseDto(
         LocalDateTime createdAt,
 
         String content,
-        boolean isWriter
+        boolean isArticleWriter
 ) {
     public static ReplyCommentResponseDto fromEntity(Member loginMember, ReplyComment replyComment) {
         return new ReplyCommentResponseDto(

--- a/src/main/java/dormitoryfamily/doomz/domain/wish/service/WishService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/wish/service/WishService.java
@@ -84,7 +84,7 @@ public class WishService {
         Slice<Article> articles = articleRepository
                 .findAllByIdInAndDormitoryTypeAndBoardType(articleIds, dormitoryType, null, request, pageable);
 
-        return ArticleListResponseDto.fromResponseDtos(articles, getSimpleArticleResponseDto(articles));
+        return ArticleListResponseDto.fromResponseDtos(loginMember, articles, getSimpleArticleResponseDto(articles));
     }
 
     private List<Long> getArticleIds(List<Wish> wishes) {


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)
- [x] 리팩토링 (Refactoring)

### - **간략한 설명**
  - 게시글, 댓글 조회시 응답 DTO에 `loginMemberId`를 추가했습니다.
  - 댓글 조회 응답 DTO에 `isWriter` 변수를 `isArticleWriter`로 수정했습니다.

---

## 🛠 주요 작성/변경 사항

### - 게시글, 댓글 응답 DTO에 `loginMemberId` 추가
  - 프론트에서 로그인 사용자에 따라 다른 UI를 제공하기 위해서 게시글, 댓글 조회 API의 응답 메시지에 로그인한 사용자의 ID를 제공해달라는 요청이 있었습니다.
  - 단건 게시글, 게시글 리스트, 댓글 조회 응답 DTO에 로그인한 사용자의 ID를 추가했습니다.

### - 댓글 조회 DTO `isArticleWriter` 변수로 수정
  - 댓글 조회 시 두 가지 정보를 프론트측에 전달해야 합니다.
    1. 현재 로그인한 사용자가 댓글 작성자인지 여부,
    `loginMemberId`와 각 댓글의 `memberId`를 비교하여 프론트 측에서 판단이 가능하기 때문에 별도의 boolean 변수를 추가하지 않았습니다.
    2. 해당 댓글 작성자가 게시글 작성자와 동일한지 여부,
    좀 더 명확하게 설명하기 위해서 기존의 `isWriter` 변수를 `isArticleWriter`로 수정했습니다.

### - 내가 작성한 댓글 목록 조회 API URL 변경
  - RESTFull한 URL로 사용하기 위해 명사 복수형으로 수정했습니다.
  - "/my/dormitories/{dormitoryType}/board-types/{boardType}/comments"에서 `board-type` 을 `board-types` 로 변경했습니다.

### - 내가 작성한 댓글 목록 조회 API 메소드명을 수정했습니다.

---

## 🔗 관련 이슈

- **이슈 링크** : #86 

---

## 📮 리뷰어에게 전하는 메시지
- 리뷰 부탁드립니다!
