### PR TITLE
[Fix] 권한에 따른 프로필 초기 세팅 API 호출 제한 기능 구현

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/member/controller/MemberControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/controller/MemberControllerAdvice.java
@@ -91,4 +91,13 @@ public class MemberControllerAdvice {
                 .status(status)
                 .body(ResponseDto.errorWithMessage(status, e.getMessage()));
     }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleNotVisitorRoleException(NotVisitorRoleException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/member/entity/Member.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package dormitoryfamily.doomz.domain.member.entity;
 import dormitoryfamily.doomz.domain.member.dto.request.MemberSetUpProfileRequestDto;
 import dormitoryfamily.doomz.domain.member.dto.request.MyProfileModifyRequestDto;
 import dormitoryfamily.doomz.domain.member.entity.type.*;
+import dormitoryfamily.doomz.domain.member.exception.NotVisitorRoleException;
 import dormitoryfamily.doomz.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -101,6 +102,9 @@ public class Member extends BaseTimeEntity {
     }
 
     public void setUpProfile(MemberSetUpProfileRequestDto requestDto) {
+        if (authority != RoleType.ROLE_VISITOR) {
+            throw new NotVisitorRoleException();
+        }
         this.nickname = requestDto.nickname();
         this.studentCardImageUrl = requestDto.studentCardImageUrl();
         this.collegeType = CollegeType.fromDescription(requestDto.collegeType());

--- a/src/main/java/dormitoryfamily/doomz/domain/member/exception/NotVisitorRoleException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/exception/NotVisitorRoleException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.domain.member.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class NotVisitorRoleException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.NOT_VISITOR_ROLE;
+
+    public NotVisitorRoleException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
     NOT_INITIALIZE_PROFILE(HttpStatus.UNAUTHORIZED, "초기 프로필 설정을 하지 않았습니다."),
     INVALID_MEMBER_DORMITORY_TYPE(HttpStatus.BAD_REQUEST, "해당 멤버 기숙사는 존재하지 않습니다."),
+    NOT_VISITOR_ROLE(HttpStatus.FORBIDDEN, "ROLE_VISITOR 권한만 요청할 수 있습니다."),
 
     // comment
     COMMENT_NOT_EXISTS(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 버그 수정 (Bug Fix)

### - **간략한 설명**
  - 사용자 권한이 `ROLE_VISITOR`이 아닌 경우, 프로필 초기 세팅 API를 호출했을 때 예외가 발생하도록 수정했습니다.

---

## 🛠 주요 작성/변경 사항

### -  권한에 따라 API 호출을 제한하지 않았을 때 발생할 수 있는 문제 해결
  - 기존 코드는 학생증 인증까지 완료한 `ROLE_VERIFIED_STUDENT` 권한을 가진 사용자가 다시 프로필 초기 세팅 API를 호출하면 다시 'ROLE_MEMBER'로 강등하는 현상이 발생했습니다.
  - 이를 해결하고자, OAuth 로그인을 처음 하는 `ROLE_VISITOR` 권한 상태에서만 해당 API를 호출하도록 변경했습니다.
  - 만약 권한 상태가 `ROLE_VISITOR`가 아닌 사용자가 해당 API를 호출하면 `NotVisitorRoleException`이 발생합니다.
  ```json
  {
      "code": 403,
      "errorMessage": "ROLE_VISITOR 권한만 요청할 수 있습니다."
  }
  ```

---

## 🔗 관련 이슈

- **이슈 링크** : #94 

---

## 📮 리뷰어에게 전하는 메시지
- 간단한 수정사항입니다. 리뷰 부탁드립니다 :)
