### PR TITLE
[Fix] 게시글 리스트 조회 시 정렬 기준이 인기순으로 되지 않는 버그 수정

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/article/repository/ArticleRepositoryCustomImpl.java
@@ -38,7 +38,6 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
                         articleStatus(request),
                         boardTypeEx(boardType)
                 )
-                .orderBy(article.createdAt.desc())
                 .orderBy(getOrderByExpression(request.sort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -99,7 +98,6 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
                         articleStatus(request),
                         boardTypeEx(boardType)
                 )
-                .orderBy(article.createdAt.desc())
                 .orderBy(getOrderByExpression(request.sort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -129,7 +127,6 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
                         articleStatus(request),
                         boardTypeEx(boardType)
                 )
-                .orderBy(article.createdAt.desc())
                 .orderBy(getOrderByExpression(request.sort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 버그 수정 (Bug Fix)

### - **간략한 설명**
  - 게시글(Article) 리스트 조회시 정렬 기준에 `popularity`를 적용 시켜도 항상 최신순으로 반환하는 문제가 발생했습니다.
  - 이를 수정하고자 `ArticleRepositoryCustomImpl` 클래스에서 `최신순`으로 정렬하는 코드를 삭제했습니다.

---

## 🛠 주요 작성/변경 사항

### - ArticleRepositoryCustomImpl 코드 수정
  - 입력한 정렬 기준이 적용되지 이전에 `createAt`으로 정렬하는 코드가 삽입되어 있어서 삭제했습니다.
  ```java
  .orderBy(getOrderByExpression(request.sort()))
  ```

---

## 🔗 관련 이슈

- **이슈 링크** : #99 

---

## 📮 리뷰어에게 전하는 메시지
- 리뷰 부탁드립니다!!
- 간단한 코드입니다 ㅎㅎ
