### PR TITLE
[feature] 채팅 및 팔로우 api 수정 사항 적용

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/chat/controller/ChatController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/controller/ChatController.java
@@ -1,6 +1,6 @@
 package dormitoryfamily.doomz.domain.chat.controller;
 
-import dormitoryfamily.doomz.domain.chat.dto.response.ChatHistoryListResponseDto;
+import dormitoryfamily.doomz.domain.chat.dto.response.SearchChatListResponseDto;
 import dormitoryfamily.doomz.domain.chat.dto.response.ChatListResponseDto;
 import dormitoryfamily.doomz.domain.chatRoom.service.ChatRoomService;
 import dormitoryfamily.doomz.domain.chat.service.ChatService;
@@ -47,13 +47,13 @@ public class ChatController {
     }
 
     @GetMapping("/messages/search")
-    public ResponseEntity<ResponseDto<ChatHistoryListResponseDto>> searchChatHistory(
+    public ResponseEntity<ResponseDto<SearchChatListResponseDto>> searchChatHistory(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @ModelAttribute @Valid SearchRequestDto requestDto,
             @RequestParam String sort,
             Pageable pageable
     ) {
-        ChatHistoryListResponseDto responseDto = chatService.searchChatHistory(principalDetails, requestDto, pageable, sort);
+        SearchChatListResponseDto responseDto = chatService.searchChatHistory(principalDetails, requestDto, pageable, sort);
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/dto/ChatDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/dto/ChatDto.java
@@ -16,7 +16,6 @@ public record ChatDto(
         Long chatId,
         Long senderId,
         String message,
-        String imageUrl,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonDeserialize(using = LocalDateTimeDeserializer.class)
@@ -28,7 +27,6 @@ public record ChatDto(
                 chat.getId(),
                 chat.getSenderId(),
                 chat.getMessage(),
-                chat.getImageUrl(),
                 chat.getCreatedAt()
         );
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/ChatListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/ChatListResponseDto.java
@@ -8,17 +8,17 @@ public record ChatListResponseDto(
         int nowPageNumber,
         boolean isLast,
         String roomUUID,
-        List<ChatDto> chatHistory
+        List<ChatResponseDto> chatHistory
 ) {
     public static ChatListResponseDto toDto(int nowPageNumber,
                                             boolean isLast,
                                             String roomUUID,
-                                            List<ChatDto> chatDtos
+                                            List<ChatResponseDto> chatResponseDtos
     ) {
         return new ChatListResponseDto(
                 nowPageNumber,
                 isLast,
                 roomUUID,
-                chatDtos);
+                chatResponseDtos);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/ChatResponseDto.java
@@ -1,0 +1,30 @@
+package dormitoryfamily.doomz.domain.chat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dormitoryfamily.doomz.domain.chat.dto.ChatDto;
+import dormitoryfamily.doomz.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+public record ChatResponseDto(
+        Long memberId,
+        boolean isSender,
+        String memberNickname,
+        String memberProfileUrl,
+        String chatMessage,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime sentTime
+) {
+    public static ChatResponseDto fromChatDto(ChatDto chatDto, Member chatMember, boolean isChatSender) {
+        return new ChatResponseDto(
+                chatMember.getId(),
+                isChatSender,
+                chatMember.getNickname(),
+                chatMember.getProfileUrl(),
+                chatDto.message(),
+                chatDto.sentTime()
+        );
+    }
+
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/SearchChatListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/SearchChatListResponseDto.java
@@ -5,16 +5,16 @@ import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-public record ChatHistoryListResponseDto(
+public record SearchChatListResponseDto(
         int nowPageNumber,
         boolean isLast,
-        List<ChatHistoryResponseDto> chatHistory
+        List<SearchChatResponseDto> chatHistory
 ) {
-    public static ChatHistoryListResponseDto toDto(Slice<Chat> chats, List<ChatHistoryResponseDto> chatHistoryResponseDto) {
-        return new ChatHistoryListResponseDto(
+    public static SearchChatListResponseDto toDto(Slice<Chat> chats, List<SearchChatResponseDto> SearchChatResponseDto) {
+        return new SearchChatListResponseDto(
                 chats.getNumber(),
                 chats.isLast(),
-                chatHistoryResponseDto
+                SearchChatResponseDto
         );
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/SearchChatResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/SearchChatResponseDto.java
@@ -6,7 +6,7 @@ import dormitoryfamily.doomz.domain.member.entity.Member;
 
 import java.time.LocalDateTime;
 
-public record ChatHistoryResponseDto(
+public record SearchChatResponseDto(
         Long roomId,
         Long memberId,
         String memberNickname,
@@ -16,8 +16,8 @@ public record ChatHistoryResponseDto(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime chatMessageTime
 ) {
-    public static ChatHistoryResponseDto fromEntity(Chat chat, Member member) {
-        return new ChatHistoryResponseDto(
+    public static SearchChatResponseDto fromEntity(Chat chat, Member member) {
+        return new SearchChatResponseDto(
                 chat.getChatRoom().getId(),
                 member.getId(),
                 member.getNickname(),

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/SearchChatResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/dto/response/SearchChatResponseDto.java
@@ -14,7 +14,7 @@ public record SearchChatResponseDto(
         String chatMessage,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime chatMessageTime
+        LocalDateTime sentTime
 ) {
     public static SearchChatResponseDto fromEntity(Chat chat, Member member) {
         return new SearchChatResponseDto(

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/entity/Chat.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/entity/Chat.java
@@ -24,17 +24,14 @@ public class Chat extends BaseTimeEntity {
 
     private String message;
 
-    private String imageUrl;
-
     @ManyToOne
     @JoinColumn(name = "room_uuid", referencedColumnName = "room_uuid")
     private ChatRoom chatRoom;
 
     @Builder
-    public Chat(Long senderId, String message, String imageUrl, ChatRoom chatRoom) {
+    public Chat(Long senderId, String message, ChatRoom chatRoom) {
         this.senderId = senderId;
         this.message = message;
-        this.imageUrl = imageUrl;
         this.chatRoom = chatRoom;
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/repository/ChatRepository.java
@@ -25,4 +25,6 @@ public interface ChatRepository extends JpaRepository<Chat, Long>, ChatRepositor
     @Transactional
     @Modifying
     void deleteByCreatedAtBefore(LocalDateTime enteredAt);
+
+    boolean existsByChatRoomRoomUUID(String roomUUID);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/service/ChatService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/service/ChatService.java
@@ -1,7 +1,7 @@
 package dormitoryfamily.doomz.domain.chat.service;
 
-import dormitoryfamily.doomz.domain.chat.dto.response.ChatHistoryListResponseDto;
-import dormitoryfamily.doomz.domain.chat.dto.response.ChatHistoryResponseDto;
+import dormitoryfamily.doomz.domain.chat.dto.response.SearchChatListResponseDto;
+import dormitoryfamily.doomz.domain.chat.dto.response.SearchChatResponseDto;
 import dormitoryfamily.doomz.domain.chat.dto.response.ChatListResponseDto;
 import dormitoryfamily.doomz.domain.chat.entity.Chat;
 import dormitoryfamily.doomz.domain.chat.repository.ChatRepository;
@@ -173,16 +173,16 @@ public class ChatService {
         }
     }
 
-    public ChatHistoryListResponseDto searchChatHistory(PrincipalDetails principalDetails, SearchRequestDto requestDto, Pageable pageable, String sortType) {
+    public SearchChatListResponseDto searchChatHistory(PrincipalDetails principalDetails, SearchRequestDto requestDto, Pageable pageable, String sortType) {
         Member loginMember = principalDetails.getMember();
         Slice<Chat> chatMessages = chatRepository.findByChatMessage(loginMember, requestDto.q(), pageable, sortType);
-        List<ChatHistoryResponseDto> chatHistoryDtos = chatMessages.stream().map(
+        List<SearchChatResponseDto> searchChatDtos = chatMessages.stream().map(
                 chat -> {
                     Member chatMember = chat.getChatRoom().getSender().getId().equals(loginMember.getId()) ?
                             chat.getChatRoom().getReceiver() : chat.getChatRoom().getSender();
-                    return ChatHistoryResponseDto.fromEntity(chat, chatMember);
+                    return SearchChatResponseDto.fromEntity(chat, chatMember);
                 }
         ).collect(Collectors.toList());
-        return ChatHistoryListResponseDto.toDto(chatMessages, chatHistoryDtos);
+        return SearchChatListResponseDto.toDto(chatMessages, searchChatDtos);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chat/service/ChatService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/service/ChatService.java
@@ -150,10 +150,14 @@ public class ChatService {
 
     public void validateChat(ChatMessage chatMessage) {
         Long senderId = chatMessage.getSenderId();
-        ChatRoom chatRoom = getChatRoomByRoomUUID(chatMessage.getRoomUUID());
-
+        ChatRoom chatRoom = findChatRoomByUUID(chatMessage.getRoomUUID());
         validateMemberInChatRoom(chatRoom, senderId);
         validateChatMessage(chatMessage);
+    }
+
+    private ChatRoom findChatRoomByUUID(String roomUUID) {
+        Optional<ChatRoom> optionalChatRoom = chatRoomRepository.findByRoomUUID(roomUUID);
+        return optionalChatRoom.orElseThrow(() -> new InvalidChatMessageException("존재하지 않는 채팅방입니다."));
     }
 
     private void validateMemberInChatRoom(ChatRoom chatRoom, Long senderId) {
@@ -164,11 +168,8 @@ public class ChatService {
     }
 
     private void validateChatMessage(ChatMessage chatMessage) {
-        boolean hasMessage = chatMessage.getMessage() != null && !chatMessage.getMessage().isEmpty();
-        boolean hasImageUrl = chatMessage.getImageUrl() != null && !chatMessage.getImageUrl().isEmpty();
-
-        if (hasMessage && hasImageUrl || !(hasMessage || hasImageUrl)) {
-            throw new InvalidChatMessageException("메시지 또는 이미지 URL 중 하나만 존재해야 합니다.");
+        if (chatMessage.getMessage() == null || chatMessage.getMessage().isEmpty()) {
+            throw new InvalidChatMessageException("메세지가 없습니다.");
         }
     }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package dormitoryfamily.doomz.domain.chatRoom.controller;
 
+import dormitoryfamily.doomz.domain.chatRoom.dto.response.ChatRoomIdResponseDto;
 import dormitoryfamily.doomz.domain.chatRoom.dto.response.UnreadChatCountResponseDto;
 import dormitoryfamily.doomz.domain.chatRoom.dto.response.ChatRoomListResponseDto;
 import dormitoryfamily.doomz.domain.chatRoom.dto.response.CreateChatRoomResponseDto;
@@ -28,6 +29,15 @@ public class ChatRoomController {
     ) {
         CreateChatRoomResponseDto responseDto = chatRoomService.createChatRoom(memberId, principalDetails);
         return ResponseEntity.ok(ResponseDto.createdWithData(responseDto));
+    }
+
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<ResponseDto<ChatRoomIdResponseDto>> findChatRoomByMember(
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        ChatRoomIdResponseDto responseDto = chatRoomService.findChatRoomByMember(memberId, principalDetails);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 
     @DeleteMapping("/rooms/{roomId}")

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomController.java
@@ -39,6 +39,14 @@ public class ChatRoomController {
         return ResponseEntity.ok(ResponseDto.ok());
     }
 
+    @DeleteMapping("/rooms/{roomId}/no-messages")
+    public ResponseEntity<ResponseDto<Void>> deleteEmptyRoom(
+            @PathVariable Long roomId
+    ) {
+        chatRoomService.deleteEmptyChatRoom(roomId);
+        return ResponseEntity.ok(ResponseDto.ok());
+    }
+
     @GetMapping("/rooms")
     public ResponseEntity<ResponseDto<ChatRoomListResponseDto>> findAllChatRooms(
             @AuthenticationPrincipal PrincipalDetails principalDetails,

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomControllerAdvice.java
@@ -57,6 +57,15 @@ public class ChatRoomControllerAdvice {
                 .body(ResponseDto.errorWithMessage(status, e.getMessage()));
     }
 
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> MemberChatRoomNotExistsException(MemberChatRoomNotExistsException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+
     @MessageExceptionHandler
     @SendToUser("/queue/errors")
     public ResponseEntity<ResponseDto<Void>> handleInvalidChatMessageException(MemberNotInChatRoomException e) {

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomControllerAdvice.java
@@ -48,6 +48,15 @@ public class ChatRoomControllerAdvice {
                 .body(ResponseDto.errorWithMessage(status, e.getMessage()));
     }
 
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleChatRoomNotEmptyException(ChatRoomNotEmptyException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage()));
+    }
+
     @MessageExceptionHandler
     @SendToUser("/queue/errors")
     public ResponseEntity<ResponseDto<Void>> handleInvalidChatMessageException(MemberNotInChatRoomException e) {

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/controller/ChatRoomControllerAdvice.java
@@ -58,7 +58,7 @@ public class ChatRoomControllerAdvice {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> MemberChatRoomNotExistsException(MemberChatRoomNotExistsException e) {
+    public ResponseEntity<ResponseDto<Void>> handleMemberChatRoomNotExistsException(MemberChatRoomNotExistsException e) {
         HttpStatus status = e.getErrorCode().getHttpStatus();
 
         return ResponseEntity

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/dto/response/ChatRoomIdResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/dto/response/ChatRoomIdResponseDto.java
@@ -1,0 +1,11 @@
+package dormitoryfamily.doomz.domain.chatRoom.dto.response;
+
+import dormitoryfamily.doomz.domain.chatRoom.entity.ChatRoom;
+
+public record ChatRoomIdResponseDto (
+        Long roomId
+){
+    public static ChatRoomIdResponseDto fromEntity(ChatRoom chatRoom){
+        return new ChatRoomIdResponseDto(chatRoom.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/dto/response/ChatRoomResponseDto.java
@@ -30,7 +30,7 @@ public record ChatRoomResponseDto (
                         member.getNickname(),
                         member.getProfileUrl(),
                         unreadCount,
-                        lastChat.getMessage() != null ? lastChat.getMessage() : lastChat.getImageUrl(),
+                        lastChat.getMessage(),
                         lastChat.getCreatedAt()
                 );
         }

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/exception/ChatRoomNotEmptyException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/exception/ChatRoomNotEmptyException.java
@@ -3,12 +3,11 @@ package dormitoryfamily.doomz.domain.chatRoom.exception;
 import dormitoryfamily.doomz.global.exception.ApplicationException;
 import dormitoryfamily.doomz.global.exception.ErrorCode;
 
-public class CannotChatYourselfException extends ApplicationException {
+public class ChatRoomNotEmptyException extends ApplicationException {
 
-    private static final ErrorCode ERROR_CODE = ErrorCode.CANNOT_CHAT_YOURSELF;
+    private static final ErrorCode ERROR_CODE = ErrorCode.CHAT_ROOM_NOT_EMPTY;
 
-    public CannotChatYourselfException() {
+    public ChatRoomNotEmptyException() {
         super(ERROR_CODE);
     }
 }
-

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/exception/MemberChatRoomNotExistsException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/exception/MemberChatRoomNotExistsException.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.domain.chatRoom.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+
+public class MemberChatRoomNotExistsException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.MEMBER_CHAT_ROOM_NOT_EXISTS;
+
+    public MemberChatRoomNotExistsException () {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/service/ChatRoomService.java
@@ -4,10 +4,7 @@ import dormitoryfamily.doomz.domain.chat.entity.Chat;
 import dormitoryfamily.doomz.domain.chat.exception.ChatNotExistsException;
 import dormitoryfamily.doomz.domain.chat.repository.ChatRepository;
 import dormitoryfamily.doomz.domain.chat.service.ChatService;
-import dormitoryfamily.doomz.domain.chatRoom.dto.response.ChatRoomListResponseDto;
-import dormitoryfamily.doomz.domain.chatRoom.dto.response.ChatRoomResponseDto;
-import dormitoryfamily.doomz.domain.chatRoom.dto.response.CreateChatRoomResponseDto;
-import dormitoryfamily.doomz.domain.chatRoom.dto.response.UnreadChatCountResponseDto;
+import dormitoryfamily.doomz.domain.chatRoom.dto.response.*;
 import dormitoryfamily.doomz.domain.chatRoom.entity.ChatRoom;
 import dormitoryfamily.doomz.domain.chatRoom.exception.*;
 import dormitoryfamily.doomz.domain.chatRoom.repository.ChatRoomRepository;
@@ -240,5 +237,15 @@ public class ChatRoomService {
         List<ChatRoomResponseDto> chatRoomDtos = createChatRoomResponseDtos(chatRooms.stream().toList(), loginMember);
         chatRoomDtos.sort(Comparator.comparing(ChatRoomResponseDto::lastMessageTime).reversed());
         return ChatRoomListResponseDto.toDto(chatRooms, chatRoomDtos);
+    }
+
+    public ChatRoomIdResponseDto findChatRoomByMember(Long memberId, PrincipalDetails principalDetails) {
+        Member loggedInMember = principalDetails.getMember();
+        Member chatMember = getMemberById(memberId);
+
+        ChatRoom chatRoom = chatRoomRepository.findBySenderAndReceiver(loggedInMember, chatMember)
+                .orElseThrow(MemberChatRoomNotExistsException::new);
+
+        return ChatRoomIdResponseDto.fromEntity(chatRoom);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/service/ChatRoomService.java
@@ -136,7 +136,7 @@ public class ChatRoomService {
         boolean isSenderDeleted = chatRoom.getSenderEnteredAt() == null;
         boolean isReceiverDeleted = chatRoom.getReceiverEnteredAt() == null;
 
-        validateRoomLeft(isSender, isSenderDeleted, isReceiverDeleted);
+        checkIfRoomAlreadyLeft(isSender, isSenderDeleted, isReceiverDeleted);
         deleteOrChangeChatRoomStatus(chatRoom, isSender, isSenderDeleted, isReceiverDeleted);
     }
 
@@ -152,7 +152,7 @@ public class ChatRoomService {
         }
     }
 
-    private void validateRoomLeft(boolean isSender, boolean isSenderDeleted, boolean isReceiverDeleted) {
+    private void checkIfRoomAlreadyLeft(boolean isSender, boolean isSenderDeleted, boolean isReceiverDeleted) {
         if ((isSender && isSenderDeleted) || (!isSender && isReceiverDeleted)) {
             throw new AlreadyChatRoomLeftException();
         }

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/service/ChatRoomService.java
@@ -133,13 +133,13 @@ public class ChatRoomService {
     public void deleteChatRoom(Long roomId, PrincipalDetails principalDetails) {
         Member loginMember = principalDetails.getMember();
         ChatRoom chatRoom = getChatRoomById(roomId);
-        checkMemberAccess(chatRoom, loginMember);
+        validateMemberAccess(chatRoom, loginMember);
 
         boolean isSender = chatRoom.getSender().getId().equals(loginMember.getId());
         boolean isSenderDeleted = chatRoom.getSenderEnteredAt() == null;
         boolean isReceiverDeleted = chatRoom.getReceiverEnteredAt() == null;
 
-        checkIfRoomAlreadyLeft(isSender, isSenderDeleted, isReceiverDeleted);
+        validateRoomLeft(isSender, isSenderDeleted, isReceiverDeleted);
         deleteOrChangeChatRoomStatus(chatRoom, isSender, isSenderDeleted, isReceiverDeleted);
     }
 
@@ -148,14 +148,14 @@ public class ChatRoomService {
                 .orElseThrow(ChatRoomNotExistsException::new);
     }
 
-    private void checkMemberAccess(ChatRoom chatRoom, Member loginMember) {
+    private void validateMemberAccess(ChatRoom chatRoom, Member loginMember) {
         if (!chatRoom.getSender().getId().equals(loginMember.getId()) &&
                 !chatRoom.getReceiver().getId().equals(loginMember.getId())) {
             throw new InvalidMemberAccessException();
         }
     }
 
-    private void checkIfRoomAlreadyLeft(boolean isSender, boolean isSenderDeleted, boolean isReceiverDeleted) {
+    private void validateRoomLeft(boolean isSender, boolean isSenderDeleted, boolean isReceiverDeleted) {
         if ((isSender && isSenderDeleted) || (!isSender && isReceiverDeleted)) {
             throw new AlreadyChatRoomLeftException();
         }

--- a/src/main/java/dormitoryfamily/doomz/domain/follow/service/FollowService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/follow/service/FollowService.java
@@ -5,6 +5,7 @@ import dormitoryfamily.doomz.domain.follow.exception.AlreadyFollowingException;
 import dormitoryfamily.doomz.domain.follow.exception.CannotFollowYourselfException;
 import dormitoryfamily.doomz.domain.follow.exception.NotFollowingMemberException;
 import dormitoryfamily.doomz.domain.follow.repository.FollowRepository;
+import dormitoryfamily.doomz.domain.member.dto.response.MemberProfileFollowResponseDto;
 import dormitoryfamily.doomz.domain.member.dto.response.MemberProfileListResponseDto;
 import dormitoryfamily.doomz.domain.member.dto.response.MemberProfilePagingListResponseDto;
 import dormitoryfamily.doomz.domain.member.dto.response.MemberProfileResponseDto;
@@ -21,7 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -99,8 +99,12 @@ public class FollowService {
     public MemberProfilePagingListResponseDto getMyFollowerMemberList(PrincipalDetails principalDetails, Pageable pageable) {
         Member loginMember = principalDetails.getMember();
         Page<Follow> followers = followRepository.findAllByFollowingOrderByCreatedAtDesc(loginMember, pageable);
-        List<MemberProfileResponseDto> memberProfiles = followers.getContent().stream()
-                .map(follow -> MemberProfileResponseDto.fromEntity(follow.getFollower()))
+        List<MemberProfileFollowResponseDto> memberProfiles = followers.getContent().stream()
+                .map(follow -> {
+                    Member follower = follow.getFollower();
+                    boolean isFollowing = followRepository.findByFollowerAndFollowing(loginMember, follower).isPresent();
+                    return MemberProfileFollowResponseDto.fromEntity(follower, isFollowing);
+                })
                 .collect(Collectors.toList());
         return MemberProfilePagingListResponseDto.toDto(followers, memberProfiles);
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileBaseResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileBaseResponseDto.java
@@ -1,0 +1,4 @@
+package dormitoryfamily.doomz.domain.member.dto.response;
+
+public interface MemberProfileBaseResponseDto {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileFollowResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileFollowResponseDto.java
@@ -1,0 +1,20 @@
+package dormitoryfamily.doomz.domain.member.dto.response;
+
+import dormitoryfamily.doomz.domain.member.entity.Member;
+
+public record MemberProfileFollowResponseDto(
+        Long memberId,
+        String nickname,
+        String profileUrl,
+        boolean isFollowing
+) implements MemberProfileBaseResponseDto {
+
+    public static MemberProfileFollowResponseDto fromEntity(Member member, boolean isFollowing) {
+        return new MemberProfileFollowResponseDto(
+                member.getId(),
+                member.getNickname(),
+                member.getProfileUrl(),
+                isFollowing
+        );
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileListResponseDto.java
@@ -3,7 +3,7 @@ package dormitoryfamily.doomz.domain.member.dto.response;
 import java.util.List;
 
 public record MemberProfileListResponseDto (
-        List<MemberProfileResponseDto> MemberProfiles
+        List<MemberProfileResponseDto> memberProfiles
 ){
     public static MemberProfileListResponseDto toDto(List<MemberProfileResponseDto> memberProfiles){
         return new MemberProfileListResponseDto(memberProfiles);

--- a/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfilePagingListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfilePagingListResponseDto.java
@@ -9,9 +9,9 @@ public record MemberProfilePagingListResponseDto(
         int totalPageNumber,
         int nowPageNumber,
         boolean isLast,
-        List<MemberProfileResponseDto> memberProfiles
+        List<? extends MemberProfileBaseResponseDto> memberProfiles
 ) {
-    public static MemberProfilePagingListResponseDto toDto(Page<Follow> follows, List<MemberProfileResponseDto> memberProfiles){
+    public static MemberProfilePagingListResponseDto toDto(Page<Follow> follows, List<? extends MemberProfileBaseResponseDto> memberProfiles){
         return new MemberProfilePagingListResponseDto(
                 follows.getTotalPages(),
                 follows.getNumber(),

--- a/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/dto/response/MemberProfileResponseDto.java
@@ -6,8 +6,9 @@ public record MemberProfileResponseDto(
         Long memberId,
         String nickname,
         String profileUrl
-){
-    public static MemberProfileResponseDto fromEntity(Member member){
+) implements MemberProfileBaseResponseDto {
+
+    public static MemberProfileResponseDto fromEntity(Member member) {
         return new MemberProfileResponseDto(
                 member.getId(),
                 member.getNickname(),
@@ -15,3 +16,4 @@ public record MemberProfileResponseDto(
         );
     }
 }
+

--- a/src/main/java/dormitoryfamily/doomz/global/chat/ChatMessage.java
+++ b/src/main/java/dormitoryfamily/doomz/global/chat/ChatMessage.java
@@ -17,13 +17,11 @@ public class ChatMessage implements Serializable {
     private String roomUUID;
     private Long senderId;
     private String message;
-    private String imageUrl;
 
     public static Chat toEntity(ChatMessage chatMessage, ChatRoom chatRoom){
         return Chat.builder()
                 .senderId(chatMessage.getSenderId())
                 .message(chatMessage.getMessage())
-                .imageUrl(chatMessage.getImageUrl())
                 .chatRoom(chatRoom)
                 .build();
     }

--- a/src/main/java/dormitoryfamily/doomz/global/config/WebSocketConfig.java
+++ b/src/main/java/dormitoryfamily/doomz/global/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package dormitoryfamily.doomz.global.config;
 import dormitoryfamily.doomz.global.jwt.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -27,10 +28,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .addEndpoint("/stomp")
                 .setAllowedOrigins("*");
     }
-/*
+
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);
     }
-*/
 }

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     ALREADY_CHAT_ROOM_LEFT(HttpStatus.CONFLICT, "이미 나간 채팅방입니다."),
     ALREADY_IN_CHAT_ROOM(HttpStatus.CONFLICT, "이미 채팅방에 입장한 상태입니다"),
     MEMBER_NOT_IN_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방에 속해있지 않는 사용자입니다."),
+    CHAT_ROOM_NOT_EMPTY(HttpStatus.BAD_REQUEST, "빈 채팅방이 아닙니다."),
 
     //chat
     CHAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "채팅 기록이 존재하지 않는 채팅방입니다."),

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -67,7 +67,6 @@ public enum ErrorCode {
 
     //chat
     CHAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "채팅 기록이 존재하지 않는 채팅방입니다."),
-    CHAT_SINGLE_CONTENT_REQUIRED(HttpStatus.CONFLICT, "메시지 또는 이미지 URL 중 하나만 존재해야 합니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
     ALREADY_IN_CHAT_ROOM(HttpStatus.CONFLICT, "이미 채팅방에 입장한 상태입니다"),
     MEMBER_NOT_IN_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방에 속해있지 않는 사용자입니다."),
     CHAT_ROOM_NOT_EMPTY(HttpStatus.BAD_REQUEST, "빈 채팅방이 아닙니다."),
+    MEMBER_CHAT_ROOM_NOT_EXISTS(HttpStatus.NOT_FOUND, "해당 사용자와의 채팅방이 존재하지 않습니다."),
 
     //chat
     CHAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "채팅 기록이 존재하지 않는 채팅방입니다."),

--- a/src/main/java/dormitoryfamily/doomz/global/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/dormitoryfamily/doomz/global/jwt/JWTAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             // 토큰 값 자체 유무 확인
-            if (headerAuth == null || !headerAuth.startsWith("Bearer")) {
+            if (headerAuth == null || !headerAuth.startsWith(TOKEN_PREFIX)) {
                 throw new AccessTokenNotExistsException();
             }
             jwt = headerAuth.replace(TOKEN_PREFIX, "");


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)


### - *간략한 설명*
변경 사항은 다음과 같습니다.
- 채팅 조회에 대한 응답
     - 로그인한 사용자가 해당 채팅을 발송한 사용자인지에 대한 여부를 추가합니다. 
     - 채팅을 발송한 사용자의 닉네임과 프로필 이미지 추가를 추가합니다.
- 채팅방을 생성하고 채팅을 보내지 않을 시 채팅방을 삭제하는 api를 추가합니다.
- 멤버 아이디를 통해 채팅방을 조회(프로필을 통해 채팅방에 들어가 경우)하는 api 추가합니다. 
- 웹소켓 요청시 jwt 인증 추가합니다.
- 채팅 발송시 이미지를 첨부하는 기능 구현이 보류되어 관련 코드를 삭제합니다.
- 팔로워 조회시 해당 사용자를 내가 팔로잉하고 있는지에 대한 여부를 추가합니다.

---

## 🛠 주요 작성/변경 사항
### - 채팅 조회시 응답 정보를 추가했습니다.

기존에는 redis에 저장되는 형식인 chatDto 그대로 반환을 했지만, 새로 chatResponseDto를 생성하여 발송자 여부, 프로필 이미지, 닉네임을 추가하도록 했습니다. 
```java
  private List<ChatResponseDto> getChatResponseDtoList(Set<ChatDto> chatSet, ChatRoom chatRoom, Member loginMember) {
        List<ChatDto> chatList = new ArrayList<>(chatSet);
        return chatList.stream()
                .map(chat -> {
                    Member chatMember = Objects.equals(chat.senderId(), chatRoom.getSender().getId()) ?
                            chatRoom.getSender() : chatRoom.getReceiver();  //채팅을 보낸 멤버를 찾아서 저장
                    boolean isChatSender = chat.senderId().equals(loginMember.getId()); //로그인한 사용자와 비교
                    return ChatResponseDto.fromChatDto(chat, chatMember, isChatSender);
                })
                .collect(Collectors.toList());
    }
```

### - 웹소켓 요청을 보낼 때도 jwt  인증을 하도록 추가하였습니다. 
  - ChannelInterceptor를 implements한 StompHandler에서 jwt 토큰을 검증합니다. 헤더에서 토큰을 가져오는 방식을 제외하고는 http 요청시 인증 로직과 동일하게 동작합니다.
  ```
public class StompHandler implements ChannelInterceptor {

    @Override
    public Message<?> preSend(Message<?> message, MessageChannel channel) {

        String headerAuth = null;

        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);  //STOMP 헤더에 접근
        if(accessor.getCommand() == StompCommand.CONNECT) {    //CONNECT 명령어가 들어왔을 때만 실행
            headerAuth = accessor.getFirstNativeHeader(HEADER_STRING_ACCESS);
        }
  ```

---

## 💡 특이 사항 및 고민사항

### - 채팅방 삭제(나가기) api와 빈 채팅방 삭제 api 차이점
  - 채팅방 삭제 api는 기본적으로 해당 채팅방에서 나눈 채팅이 존재하는 전제를 바탕으로 합니다. 따라서, 한 명이 나갈 경우 채팅방을 나가지 않은 사용자는 그대로 채팅방에 존재합니다.
  - 빈 채팅방을 삭제하는 api는 사용자가 채팅방을 생성하고 채팅을 발송하지 않을 경우 프론트엔드에서 채팅방을 삭제하도록 요청하는 api입니다.

### -팔로잉/팔로워 조회 시 프로필 응답 dto에서 인터페이스 사용
- 팔로잉 목록 조회와  팔로워 목록 조회 모두 멤버 프로필을 페이징하여 응답하지만, 프로필에 담기는 정보에 차이가 있습니다. 아직 구현하지 않은 둠즈 목록의 경우에도 비슷하게 멤버 프로필을 페이징하여 응답할 거라 예상했습니다. 따라서  각 경우마다 MemberProfilePagingListResponseDto를 생성하는 것 보다 하나의 MemberProfilePagingListResponseDto를 생성하고, memberProfiles 부분을 인터페이스를 구현하는 것이 더 효율적이라고 생각하여 인터페이스를 사용하였습니다. record가 아닌 class를 사용하여 상속으로 변경하거나,  둠즈 목록에서 해당 부분이 사용되지 않을 경우 코드가 변경될 수 있습니다.
```
public record MemberProfilePagingListResponseDto(
        int totalPageNumber,
        int nowPageNumber,
        boolean isLast,
        List<? extends MemberProfileBaseResponseDto> memberProfiles //인터페이스 사용
) {
}
```  
---

## 🔗 관련 이슈

- **이슈 링크** : #102

---

## 📮 리뷰어에게 전하는 메시지
- stompHandler jwt 인증 관련 코드 확인해주시면 감사하겠습니다ㅎㅎ

