### PR TITLE
[Fix] 댓글 조회시 isArticleWriter가 잘못 출력되고 있었던 문제 해결

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/dto/response/CommentResponseDto.java
@@ -25,7 +25,7 @@ public record CommentResponseDto (
         boolean isDeleted,
         List<ReplyCommentResponseDto> replyComments
 ){
-    public static CommentResponseDto fromEntity(Member loginMember, Comment comment){
+    public static CommentResponseDto fromEntity(Member articleWriter, Comment comment){
         return new CommentResponseDto(
                 comment.getId(),
                 comment.getMember().getId(),
@@ -33,15 +33,15 @@ public record CommentResponseDto (
                 comment.getMember().getNickname(),
                 comment.getCreatedAt(),
                 comment.getContent(),
-                isArticleWriter(loginMember, comment.getArticle().getMember()),
+                isArticleWriter(articleWriter, comment.getArticle().getMember()),
                 comment.isDeleted(),
                 comment.getReplyComments().stream()
-                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(loginMember, replyComment))
+                        .map(replyComment -> ReplyCommentResponseDto.fromEntity(articleWriter, replyComment))
                         .collect(toList())
         );
     }
 
-    private static boolean isArticleWriter(Member loginMember, Member ArticleWriter) {
-        return Objects.equals(loginMember.getId(), ArticleWriter.getId());
+    private static boolean isArticleWriter(Member articleWriter, Member commentWriter) {
+        return Objects.equals(articleWriter.getId(), commentWriter.getId());
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/comment/service/CommentService.java
@@ -59,7 +59,7 @@ public class CommentService {
         Article article = getArticleById(articleId);
         List<Comment> comments = commentRepository.findAllByArticleIdOrderByCreatedAtAsc(articleId);
         List<CommentResponseDto> commentResponseDto = comments.stream()
-                .map(comment -> CommentResponseDto.fromEntity(loginMember, comment))
+                .map(comment -> CommentResponseDto.fromEntity(article.getMember(), comment))
                 .collect(toList());
         return CommentListResponseDto.toDto(loginMember, article.getCommentCount(), commentResponseDto);
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/replyComment/dto/response/ReplyCommentResponseDto.java
@@ -19,7 +19,7 @@ public record ReplyCommentResponseDto(
         String content,
         boolean isArticleWriter
 ) {
-    public static ReplyCommentResponseDto fromEntity(Member loginMember, ReplyComment replyComment) {
+    public static ReplyCommentResponseDto fromEntity(Member articleWriter, ReplyComment replyComment) {
         return new ReplyCommentResponseDto(
                 replyComment.getId(),
                 replyComment.getMember().getId(),
@@ -27,12 +27,12 @@ public record ReplyCommentResponseDto(
                 replyComment.getMember().getNickname(),
                 replyComment.getCreatedAt(),
                 replyComment.getContent(),
-                isArticleWriter(loginMember, replyComment.getComment().getArticle().getMember())
+                isArticleWriter(articleWriter, replyComment.getMember())
         );
     }
 
-    private static boolean isArticleWriter(Member loginMember, Member articleWriter) {
-        return Objects.equals(loginMember.getId(), articleWriter.getId());
+    private static boolean isArticleWriter(Member articleWriter, Member replyCommentWriter) {
+        return Objects.equals(articleWriter.getId(), replyCommentWriter.getId());
     }
 }
 


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 버그 수정 (Bug Fix)

### - **간략한 설명**
  - 댓글 조회시 `isArticleWriter` 정보가 현재는 `로그인 사용자`와 `댓글 작성자` 관계로 출력되고 있습니다.
  - 이를 올바르게 수정하여, `댓글 작성자`와 `게시글 작성자`가 동일인인지 나타내도록 수정했습니다.

---

## 🛠 주요 작성/변경 사항

### - CommentResponseDto 내부 로직 수정
  - 기존 코드는 `loginMember`와 `CommentWriter`을 비교해서 값을 출력하도록 했습니다.
  ```java
  isArticleWriter(loginMember, comment.getArticle().getMember()),
  ```
  - 매개변수의 `loginMember`를 `Article.getMember()`로 수정했습니다.
   ```java
  isArticleWriter(articleWriter, comment.getArticle().getMember()),
  ```

  - 대댓글 Dto도 동일하게 적용했습니다.

---

## 🔗 관련 이슈

- **이슈 링크** : #104 

---

## 📮 리뷰어에게 전하는 메시지
- 이전에 해당 내용을 수정할 때 헷갈려서 잘못 작성했던 것 같습니다.. ㅎㅎ
