### PR TITLE
[fix] 채팅 FK 관련 예외 해결 및 채팅 정렬 순서 변경

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/chat/service/ChatService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chat/service/ChatService.java
@@ -158,7 +158,6 @@ public class ChatService {
 
     private List<ChatResponseDto> CreateChatResponseDtoList(Set<ChatDto> chatSet, ChatRoom chatRoom, Member loginMember) {
         List<ChatDto> chatList = new ArrayList<>(chatSet);
-        Collections.reverse(chatList);
         return chatList.stream()
                 .map(chat -> {
                     Member chatMember = Objects.equals(chat.senderId(), chatRoom.getInitiator().getId()) ?

--- a/src/main/java/dormitoryfamily/doomz/domain/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatRoom/entity/ChatRoom.java
@@ -22,6 +22,7 @@ import static dormitoryfamily.doomz.domain.chatRoom.entity.type.ChatMemberStatus
 
 @Entity
 @Getter
+@Table(name = "chat_room", indexes = @Index(name = "idx_room_uuid", columnList = "room_uuid"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends BaseTimeEntity {
 


### PR DESCRIPTION


## 🎯 목적

- [x] 리팩토링 (Refactoring)
- [x] 버그 수정 (Bug Fix)


### - **간략한 설명**
  - 프로그램 실행 시 발생하는 채팅 엔티티의 FK 예외 오류를 해결하기 위해 채팅방 uuid에 인덱스를 추가했습니다.
  - 채팅 조회 시 정렬 순서를 변경했습니다.

---

## 🛠 주요 작성/변경 사항

### - 채팅방 uuid에 인덱스를 추가
  - 현재, 채팅은 채팅방과 일대 다 관계이며 채팅은 채팅방의 PK인 chat_room_id가 아닌 아닌 웹 소켓 요청 시 사용되는 채팅방 uuid를 fk로  가집니다.
  - 이 부분에서 프로그램 실행 시, Chat 엔티티와 ChatRoom 엔티티 간의 외래 키 제약 조건을 추가하려고 할 때, ChatRoom 테이블의 room_uuid 컬럼에 적절한 인덱스가 없어서 예외가 발생했습니다.
  - 테이블 상 설계에는 문제가 없지만,  인덱스가 없을 경우 성능 문제가 발생하기 쉽기 때문에 예외가 발생한 것으로 판단하고, 채팅방의 uuid에 인덱스를 설정하는 코드를 추가했습니다.
 ```java
@Table(name = "chat_room", indexes = @Index(name = "idx_room_uuid", columnList = "room_uuid"))
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class ChatRoom extends BaseTimeEntity {
```

### - 채팅 조회 시 정렬 순서 변경
* 기존에는 채팅 조회  시, 전체적으로 최신 순 정렬이고 페이지 내에서도 최신 순으로 정렬되었습니다.
* 하지만, 프론트엔드 요구 사항에 따라 페이지 내에서는 오래된 순으로 정렬하도록 변경했습니다.

---

## 🔗 관련 이슈

- **이슈 링크** : #131 

---

## 📮 리뷰어에게 전하는 메시지
- 프로그램 실행 후 해당 오류가 발생하지 않는 지 확인해주시면 감사하겠습니다!
