### PR TITLE
[Feature] 알림 기능 구현

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/DoomzApplication.java
+++ b/src/main/java/dormitoryfamily/doomz/DoomzApplication.java
@@ -3,13 +3,14 @@ package dormitoryfamily.doomz;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class DoomzApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DoomzApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(DoomzApplication.class, args);
+    }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/board/article/entity/ArticleImage.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/article/entity/ArticleImage.java
@@ -22,6 +22,7 @@ public class ArticleImage {
     @JoinColumn(name = "article_id")
     private Article article;
 
+    @Column(length = 1000)
     private String imageUrl;
 
     @Builder

--- a/src/main/java/dormitoryfamily/doomz/domain/board/comment/event/CommentCreatedEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/comment/event/CommentCreatedEvent.java
@@ -1,0 +1,12 @@
+package dormitoryfamily.doomz.domain.board.comment.event;
+
+import dormitoryfamily.doomz.domain.board.article.entity.Article;
+import dormitoryfamily.doomz.domain.board.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+
+public record CommentCreatedEvent(
+        Comment comment,
+        Article article,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/board/comment/event/CommentCreatedListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/comment/event/CommentCreatedListener.java
@@ -1,0 +1,25 @@
+package dormitoryfamily.doomz.domain.board.comment.event;
+
+import dormitoryfamily.doomz.domain.board.article.entity.Article;
+import dormitoryfamily.doomz.domain.board.comment.entity.Comment;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCreatedListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleCommentCreatedEvent(CommentCreatedEvent event) {
+        Comment comment = event.comment();
+        Article article = event.article();
+
+        notificationService.send(article.getMember(), comment.getMember(), event.notificationType(), article.getTitle(), article.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/board/replycomment/event/ReplyCommentCreatedEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/replycomment/event/ReplyCommentCreatedEvent.java
@@ -1,0 +1,12 @@
+package dormitoryfamily.doomz.domain.board.replycomment.event;
+
+import dormitoryfamily.doomz.domain.board.article.entity.Article;
+import dormitoryfamily.doomz.domain.board.replycomment.entity.ReplyComment;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+
+public record ReplyCommentCreatedEvent(
+        ReplyComment replyComment,
+        Article article,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/board/replycomment/event/ReplyCommentCreatedListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/replycomment/event/ReplyCommentCreatedListener.java
@@ -1,0 +1,25 @@
+package dormitoryfamily.doomz.domain.board.replycomment.event;
+
+import dormitoryfamily.doomz.domain.board.article.entity.Article;
+import dormitoryfamily.doomz.domain.board.replycomment.entity.ReplyComment;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReplyCommentCreatedListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleReplyCommentCreatedEvent(ReplyCommentCreatedEvent event) {
+        ReplyComment replyComment = event.replyComment();
+        Article article = event.article();
+
+        notificationService.send(replyComment.getComment().getMember(), replyComment.getMember(), event.notificationType(), article.getTitle(), article.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/board/wish/event/ArticleWishCreatedEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/wish/event/ArticleWishCreatedEvent.java
@@ -1,0 +1,12 @@
+package dormitoryfamily.doomz.domain.board.wish.event;
+
+import dormitoryfamily.doomz.domain.board.article.entity.Article;
+import dormitoryfamily.doomz.domain.board.wish.entity.ArticleWish;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+
+public record ArticleWishCreatedEvent(
+        ArticleWish articleWish,
+        Article article,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/board/wish/event/ArticleWishCreatedListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/board/wish/event/ArticleWishCreatedListener.java
@@ -1,0 +1,25 @@
+package dormitoryfamily.doomz.domain.board.wish.event;
+
+import dormitoryfamily.doomz.domain.board.article.entity.Article;
+import dormitoryfamily.doomz.domain.board.wish.entity.ArticleWish;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleWishCreatedListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleArticleWishCreatedEvent(ArticleWishCreatedEvent event) {
+        ArticleWish articleWish = event.articleWish();
+        Article article = event.article();
+
+        notificationService.send(article.getMember(), articleWish.getMember(), event.notificationType(), article.getTitle(), article.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/chatting/chat/event/ChatCreatedEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatting/chat/event/ChatCreatedEvent.java
@@ -1,0 +1,10 @@
+package dormitoryfamily.doomz.domain.chatting.chat.event;
+
+import dormitoryfamily.doomz.domain.chatting.chat.entity.Chat;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+
+public record ChatCreatedEvent(
+        Chat chat,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/chatting/chat/event/ChatCreatedListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatting/chat/event/ChatCreatedListener.java
@@ -1,0 +1,48 @@
+package dormitoryfamily.doomz.domain.chatting.chat.event;
+
+import dormitoryfamily.doomz.domain.chatting.chat.entity.Chat;
+import dormitoryfamily.doomz.domain.chatting.chatroom.entity.ChatRoom;
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatCreatedListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleChatCreatedEvent(ChatCreatedEvent event) {
+        Chat chat = event.chat();
+        ChatRoom chatRoom = chat.getChatRoom();
+        Long senderId = chat.getSenderId();
+
+        Member receiver = getReceiver(chatRoom, senderId);
+        Member sender = getSender(chatRoom, senderId);
+
+        if(chatRoom.isMemberOutOfChatRoom(receiver.getId())) {
+            notificationService.send(receiver, sender, event.notificationType(), null, chatRoom.getId());
+        }
+    }
+
+    public Member getReceiver(ChatRoom chatRoom, Long senderId) {
+        if (chatRoom.getInitiator().getId().equals(senderId)) {
+            return chatRoom.getParticipant();
+        } else {
+            return chatRoom.getInitiator();
+        }
+    }
+
+    public Member getSender(ChatRoom chatRoom, Long senderId) {
+        if (chatRoom.getInitiator().getId().equals(senderId)) {
+            return chatRoom.getInitiator();
+        } else {
+            return chatRoom.getParticipant();
+        }
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/chatting/chatroom/entity/ChatRoom.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatting/chatroom/entity/ChatRoom.java
@@ -128,6 +128,14 @@ public class ChatRoom extends BaseTimeEntity {
         this.participantStatus = ChatMemberStatus.OUT;
     }
 
+    public boolean isMemberOutOfChatRoom(Long receiverId) {
+        if (initiator.getId().equals(receiverId)) {
+            return initiatorStatus == ChatMemberStatus.OUT;
+        } else {
+            return participantStatus == ChatMemberStatus.OUT;
+        }
+    }
+
     @PrePersist
     private void init() {
         this.initiatorUnreadCount = 0;

--- a/src/main/java/dormitoryfamily/doomz/domain/chatting/chatroom/service/ChatRoomService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/chatting/chatroom/service/ChatRoomService.java
@@ -27,6 +27,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Service
@@ -46,7 +47,7 @@ public class ChatRoomService {
 
     @PostConstruct
     private void init() {
-        topics = new HashMap<>();
+        topics = new ConcurrentHashMap<>();
     }
 
     public ChatRoomEntryResponseDto createChatRoom(Long memberId, PrincipalDetails principalDetails) {

--- a/src/main/java/dormitoryfamily/doomz/domain/member/follow/event/FollowCreatedEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/follow/event/FollowCreatedEvent.java
@@ -1,0 +1,10 @@
+package dormitoryfamily.doomz.domain.member.follow.event;
+
+import dormitoryfamily.doomz.domain.member.follow.entity.Follow;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+
+public record FollowCreatedEvent(
+        Follow follow,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/member/follow/event/FollowCreatedListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/follow/event/FollowCreatedListener.java
@@ -1,0 +1,23 @@
+package dormitoryfamily.doomz.domain.member.follow.event;
+
+import dormitoryfamily.doomz.domain.member.follow.entity.Follow;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FollowCreatedListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleCommentCreatedEvent(FollowCreatedEvent event) {
+        Follow follow = event.follow();
+
+        notificationService.send(follow.getFollowing(), follow.getFollower(), event.notificationType(), null, follow.getFollower().getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/controller/NotificationController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/controller/NotificationController.java
@@ -1,0 +1,28 @@
+package dormitoryfamily.doomz.domain.notification.controller;
+
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import dormitoryfamily.doomz.global.security.dto.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
+    ) {
+        return notificationService.subscribe(principalDetails, lastEventId);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/controller/NotificationController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/controller/NotificationController.java
@@ -1,14 +1,16 @@
 package dormitoryfamily.doomz.domain.notification.controller;
 
+import dormitoryfamily.doomz.domain.notification.dto.request.NotificationsSetReadRequestDto;
+import dormitoryfamily.doomz.domain.notification.dto.response.NotificationListResponseDto;
 import dormitoryfamily.doomz.domain.notification.service.NotificationService;
 import dormitoryfamily.doomz.global.security.dto.PrincipalDetails;
+import dormitoryfamily.doomz.global.util.ResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -24,5 +26,23 @@ public class NotificationController {
             @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
     ) {
         return notificationService.subscribe(principalDetails, lastEventId);
+    }
+
+    @GetMapping("/notifications")
+    public ResponseEntity<ResponseDto<NotificationListResponseDto>> findAllNotifications(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            Pageable pageable
+    ) {
+        NotificationListResponseDto responseDto = notificationService.getAllNotifications(principalDetails, pageable);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
+    }
+
+    @PutMapping("/notifications/read")
+    public ResponseEntity<ResponseDto<Void>> setNotificationsRead(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody NotificationsSetReadRequestDto requestDto
+    ) {
+        notificationService.setNotificationAsRead(principalDetails, requestDto);
+        return ResponseEntity.ok(ResponseDto.ok());
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/controller/NotificationControllerAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/controller/NotificationControllerAdvice.java
@@ -1,0 +1,44 @@
+package dormitoryfamily.doomz.domain.notification.controller;
+
+import dormitoryfamily.doomz.domain.notification.exception.NotMyNotificationException;
+import dormitoryfamily.doomz.domain.notification.exception.NotificationAlreadyReadException;
+import dormitoryfamily.doomz.domain.notification.exception.NotificationNotExistsException;
+import dormitoryfamily.doomz.global.util.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class NotificationControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleNotificationAlreadyReadException(NotificationAlreadyReadException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        Long alreadyReadNotificationId = e.getAlreadyReadNotificationId();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage() + " [" + alreadyReadNotificationId + "]"));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleNotificationNotExistsException(NotificationNotExistsException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        Long notExistsId = e.getNotExistsId();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage() + " [" + notExistsId + "]"));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> handleNotMyNotificationException(NotMyNotificationException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        Long wrongId = e.getWrongId();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDto.errorWithMessage(status, e.getMessage() + " [" + wrongId + "]"));
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,30 @@
+package dormitoryfamily.doomz.domain.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dormitoryfamily.doomz.domain.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponseDto(
+        Long notificationId,
+        String type,
+        String sender,
+        String articleTitle,
+        boolean isRead,
+        Long targetId,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {
+    public static NotificationResponseDto from(Notification notification) {
+        return new NotificationResponseDto(
+                notification.getId(),
+                notification.getNotificationType().toString(),
+                notification.getSender().getNickname(),
+                notification.getArticleTitle(),
+                notification.isRead(),
+                notification.getTargetId(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/dto/request/NotificationsSetReadRequestDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/dto/request/NotificationsSetReadRequestDto.java
@@ -1,0 +1,8 @@
+package dormitoryfamily.doomz.domain.notification.dto.request;
+
+import java.util.List;
+
+public record NotificationsSetReadRequestDto(
+        List<Long> notificationIds
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/dto/response/NotificationListResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/dto/response/NotificationListResponseDto.java
@@ -1,0 +1,14 @@
+package dormitoryfamily.doomz.domain.notification.dto.response;
+
+import java.util.List;
+
+public record NotificationListResponseDto(
+
+        boolean isLast,
+        List<NotificationResponseDto> notifications
+
+) {
+    public static NotificationListResponseDto from(boolean isLast, List<NotificationResponseDto> notifications) {
+        return new NotificationListResponseDto(isLast, notifications);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/dto/response/NotificationResponseDto.java
@@ -1,4 +1,4 @@
-package dormitoryfamily.doomz.domain.notification.dto;
+package dormitoryfamily.doomz.domain.notification.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dormitoryfamily.doomz.domain.notification.entity.Notification;

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/entity/Notification.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/entity/Notification.java
@@ -32,7 +32,7 @@ public class Notification extends BaseTimeEntity {
     private Member sender;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 200)
     private NotificationType notificationType;
 
     @Column(nullable = false)

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/entity/Notification.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/entity/Notification.java
@@ -1,0 +1,60 @@
+package dormitoryfamily.doomz.domain.notification.entity;
+
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+import dormitoryfamily.doomz.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+
+import static org.hibernate.annotations.OnDeleteAction.CASCADE;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_id")
+    @OnDelete(action = CASCADE)
+    private Member receiver;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id")
+    @OnDelete(action = CASCADE)
+    private Member sender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 100)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    private String articleTitle;
+    private Long targetId;
+
+    @Builder
+    public Notification(
+            Member receiver,
+            Member sender,
+            NotificationType notificationType,
+            boolean isRead,
+            String articleTitle,
+            Long targetId
+    ) {
+        this.receiver = receiver;
+        this.sender = sender;
+        this.notificationType = notificationType;
+        this.isRead = isRead;
+        this.articleTitle = articleTitle;
+        this.targetId = targetId;
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/entity/Notification.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/entity/Notification.java
@@ -57,4 +57,8 @@ public class Notification extends BaseTimeEntity {
         this.articleTitle = articleTitle;
         this.targetId = targetId;
     }
+
+    public void setReadStatusToTrue() {
+        isRead = true;
+    }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/entity/type/NotificationType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/entity/type/NotificationType.java
@@ -1,0 +1,13 @@
+package dormitoryfamily.doomz.domain.notification.entity.type;
+
+public enum NotificationType {
+    ARTICLE_COMMENT, //게시글 댓글
+    ARTICLE_WISH, //게시글 찜
+    ARTICLE_REPLY_COMMENT, //대댓글
+    MEMBER_FOLLOW, //멤버 팔로우
+    CHAT,  //채팅
+    MATCHING_WISH, //매칭 찜
+    MATCHING_REQUEST, //매칭 신청
+    MATCHING_REJECT,  //매칭 거절
+    MATCHING_DONE; //매칭 수락
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/entity/type/NotificationType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/entity/type/NotificationType.java
@@ -9,5 +9,5 @@ public enum NotificationType {
     MATCHING_WISH, //매칭 찜
     MATCHING_REQUEST, //매칭 신청
     MATCHING_REJECT,  //매칭 거절
-    MATCHING_DONE; //매칭 수락
+    MATCHING_ACCEPT //매칭 수락
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/exception/NotMyNotificationException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/exception/NotMyNotificationException.java
@@ -1,0 +1,17 @@
+package dormitoryfamily.doomz.domain.notification.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotMyNotificationException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.NOT_MY_NOTIFICATION;
+    private final Long wrongId;
+
+    public NotMyNotificationException(Long wrongId) {
+        super(ERROR_CODE);
+        this.wrongId = wrongId;
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/exception/NotificationAlreadyReadException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/exception/NotificationAlreadyReadException.java
@@ -1,0 +1,17 @@
+package dormitoryfamily.doomz.domain.notification.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotificationAlreadyReadException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.ALREADY_READ_NOTIFICATION;
+    private final Long alreadyReadNotificationId;
+
+    public NotificationAlreadyReadException(Long alreadyReadNotificationId) {
+        super(ERROR_CODE);
+        this.alreadyReadNotificationId = alreadyReadNotificationId;
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/exception/NotificationNotExistsException.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/exception/NotificationNotExistsException.java
@@ -1,0 +1,17 @@
+package dormitoryfamily.doomz.domain.notification.exception;
+
+import dormitoryfamily.doomz.global.exception.ApplicationException;
+import dormitoryfamily.doomz.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotificationNotExistsException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.NOTIFICATION_NOT_EXISTS;
+    private final Long notExistsId;
+
+    public NotificationNotExistsException(Long notExistsId) {
+        super(ERROR_CODE);
+        this.notExistsId = notExistsId;
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,17 @@
+package dormitoryfamily.doomz.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+@Repository
+public interface EmitterRepository {
+
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+    void saveEventCache(String eventCacheId, Object event);
+    Map<String, SseEmitter> findAllEmitterStartWithEmail(String memberEmail);
+    Map<String, Object> findAllEventCacheStartWithEmail(String memberEmail);
+    void deleteById(String emitterId);
+
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,45 @@
+package dormitoryfamily.doomz.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCache.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithEmail(String memberEmail) {
+        return emitters.entrySet().stream()
+                .filter(emitter -> emitter.getKey().startsWith(memberEmail))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithEmail(String email) {
+        return eventCache.entrySet().stream()
+                .filter(eventCache -> eventCache.getKey().startsWith(email))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
@@ -14,4 +14,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             "WHERE n.receiver = :receiver " +
             "ORDER BY n.isRead ASC, n.createdAt DESC")
     Page<Notification> findAllByReceiver(@Param("receiver") Member receiver, Pageable pageable);
+
+    @Query("SELECT COUNT(n) > 0 FROM Notification n WHERE n.receiver.id = :receiverId AND n.notificationType = 'CHAT' AND n.isRead = false")
+    boolean existsUnreadChatNotification(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,17 @@
 package dormitoryfamily.doomz.domain.notification.repository;
 
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
 import dormitoryfamily.doomz.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n " +
+            "WHERE n.receiver = :receiver " +
+            "ORDER BY n.isRead ASC, n.createdAt DESC")
+    Page<Notification> findAllByReceiver(@Param("receiver") Member receiver, Pageable pageable);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
@@ -5,8 +5,12 @@ import dormitoryfamily.doomz.domain.notification.entity.Notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -17,4 +21,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Query("SELECT COUNT(n) > 0 FROM Notification n WHERE n.receiver.id = :receiverId AND n.notificationType = 'CHAT' AND n.isRead = false")
     boolean existsUnreadChatNotification(@Param("receiverId") Long receiverId);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.createdAt < :timestamp")
+    void deleteByCreatedAtBefore(@Param("timestamp") LocalDateTime timestamp);
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package dormitoryfamily.doomz.domain.notification.repository;
+
+import dormitoryfamily.doomz.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
@@ -15,21 +15,19 @@ import dormitoryfamily.doomz.global.security.dto.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Objects;
 
 import static dormitoryfamily.doomz.domain.notification.util.NotificationProperties.*;
 
-//todo. 1개월 이상 된 알림 삭제하기  <6>
-//todo. 전체 알림 조회(안 읽은 거는 그대로 프론트에 반환)  <2>
-//todo. 읽은 메시지 요청 처리하기  <3>
 //todo. SSE 실시간 응답은 그냥 간단한 언급만(내용 말고)  <4>
-//todo. 채팅은 여러 기능들 확인해서 구현하기  <1>
 //todo. SSE 저장, 이벤트 저장을 전체 조회하는 기능이 진짜 필요한지 판단하기  <5>
 //todo. 현재 이벤트 발행, 리스닝을 하나로 통일할 수 있는지 확인하기  <7>
 
@@ -155,5 +153,16 @@ public class NotificationService {
 
     private void markNotificationAsRead(Notification notification) {
         notification.setReadStatusToTrue();
+    }
+
+    public boolean existsUnreadChatNotificationByReceiver(Member receiver) {
+        return notificationRepository.existsUnreadChatNotification(receiver.getId());
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
+    @Transactional
+    public void deleteOldNotifications() {
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusDays(DELETE_AFTER_DAYS);
+        notificationRepository.deleteByCreatedAtBefore(oneMonthAgo);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
@@ -27,14 +27,6 @@ import java.util.Objects;
 
 import static dormitoryfamily.doomz.domain.notification.util.NotificationProperties.*;
 
-//todo. SSE 실시간 응답은 그냥 간단한 언급만(내용 말고)  <4>
-//todo. SSE 저장, 이벤트 저장을 전체 조회하는 기능이 진짜 필요한지 판단하기  <5>
-//todo. 현재 이벤트 발행, 리스닝을 하나로 통일할 수 있는지 확인하기  <7>
-
-//todo. 확인 사항 1. 다른 사람이 행동한 것도 잘 동작하는지
-//todo. 확인 사항 2. 내 스스로 댓글, 대댓글, 찜하기 한 건 알림 안가기
-//todo. 확인 사항 3. 전체 알림 조회 잘 되는지
-//todo. 확인 사항 4. 채팅 알림 조건 확인하기 - 내가 채팅방에 없을 때 & 이미 채팅 알림이 없을 때
 @Service
 @RequiredArgsConstructor
 public class NotificationService {

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
@@ -100,7 +100,7 @@ public class NotificationService {
         emitters.forEach(
                 (emitterId, emitter) -> {
                     emitterRepository.saveEventCache(emitterId, notification);
-                    sendNotification(emitter, eventId, emitterId, NotificationResponseDto.from(notification));
+                    sendNotification(emitter, eventId, emitterId, NEW_NOTIFICATION_CREATED);
                 }
         );
     }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
@@ -16,11 +16,14 @@ import java.util.Map;
 
 import static dormitoryfamily.doomz.domain.notification.util.NotificationProperties.*;
 
-//todo. 2개월 이상 된 알림 삭제하기
-//todo. 전체 알림 조회
-//todo. 알림 특정 알림 읽음 표시
+//todo. 1개월 이상 된 알림 삭제하기
+//todo. 전체 알림 조회(안 읽은 거는 그대로 프론트에 반환)
+//todo. GET 요청 시 전체 읽음 처리하기
+//todo. SSE 실시간 응답은 그냥 간단한 언급만(내용 말고)
+//todo. 채팅은 여러 기능들 확인해서 구현하기
 //todo. 전체 읽음 처리
-//todo. 확인 사항 4. SSE 저장, 이벤트 저장을 전체 조회하는 기능이 진짜 필요한지 판단하기
+//todo. SSE 저장, 이벤트 저장을 전체 조회하는 기능이 진짜 필요한지 판단하기
+//todo. 현재 이벤트 발행, 리스닝을 하나로 통일할 수 있는지 확인하기
 
 //todo. 확인 사항 1. 다른 사람이 행동한 것도 잘 동작하는지
 //todo. 확인 사항 2. 내 스스로 댓글, 대댓글, 찜하기 한 건 알림 안가기

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/service/NotificationService.java
@@ -1,0 +1,108 @@
+package dormitoryfamily.doomz.domain.notification.service;
+
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
+import dormitoryfamily.doomz.domain.notification.dto.NotificationResponseDto;
+import dormitoryfamily.doomz.domain.notification.entity.Notification;
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+import dormitoryfamily.doomz.domain.notification.repository.EmitterRepository;
+import dormitoryfamily.doomz.domain.notification.repository.NotificationRepository;
+import dormitoryfamily.doomz.global.security.dto.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static dormitoryfamily.doomz.domain.notification.util.NotificationProperties.*;
+
+//todo. 2개월 이상 된 알림 삭제하기
+//todo. 전체 알림 조회
+//todo. 알림 특정 알림 읽음 표시
+//todo. 전체 읽음 처리
+//todo. 확인 사항 4. SSE 저장, 이벤트 저장을 전체 조회하는 기능이 진짜 필요한지 판단하기
+
+//todo. 확인 사항 1. 다른 사람이 행동한 것도 잘 동작하는지
+//todo. 확인 사항 2. 내 스스로 댓글, 대댓글, 찜하기 한 건 알림 안가기
+//todo. 확인 사항 3. 전체 알림 조회 잘 되는지
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+
+    public SseEmitter subscribe(PrincipalDetails principalDetails, String lastEventId) {
+        Member loginMember = principalDetails.getMember();
+        String emitterId = makeIdIncludedMemberEmail(loginMember.getEmail());
+
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+        sendDummyEventFor503Error(loginMember, emitter, emitterId);
+
+        if (hasLostEvents(lastEventId)) {
+            sendLostEvents(lastEventId, loginMember, emitter, emitterId);
+        }
+
+        return emitter;
+    }
+
+    private void sendLostEvents(String lastEventId, Member loginMember, SseEmitter emitter, String emitterId) {
+        Map<String, Object> leftEventCaches = emitterRepository.findAllEventCacheStartWithEmail(loginMember.getEmail());
+        leftEventCaches.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+    }
+
+    private static boolean hasLostEvents(String lastEventId) {
+        return !lastEventId.isEmpty();
+    }
+
+    private void sendDummyEventFor503Error(Member loginMember, SseEmitter emitter, String emitterId) {
+        String eventId = makeIdIncludedMemberEmail(loginMember.getEmail());
+        sendNotification(emitter, eventId, emitterId, "eventStream Created, [userEmail=" + loginMember.getEmail() + "]");
+    }
+
+    private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId)
+                    .name(EVENT_NAME)
+                    .data(data));
+        } catch (IOException e) {
+            emitterRepository.deleteById(emitterId);
+        }
+    }
+
+    private static String makeIdIncludedMemberEmail(String memberEmail) {
+        return memberEmail + SEPARATOR + System.currentTimeMillis();
+    }
+
+    public void send(Member receiver, Member sender, NotificationType notificationType, String articleTitle, Long targetId) {
+        Notification notification = notificationRepository.save(createNotification(receiver, sender, notificationType, articleTitle, targetId));
+
+        String receiverEmail = receiver.getEmail();
+        String eventId = makeIdIncludedMemberEmail(receiverEmail);
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithEmail(receiverEmail);
+        emitters.forEach(
+                (emitterId, emitter) -> {
+                    emitterRepository.saveEventCache(emitterId, notification);
+                    sendNotification(emitter, eventId, emitterId, NotificationResponseDto.from(notification));
+                }
+        );
+    }
+
+    private Notification createNotification(Member receiver, Member sender, NotificationType notificationType, String articleTitle, Long targetId) {
+        return Notification.builder()
+                .receiver(receiver)
+                .sender(sender)
+                .notificationType(notificationType)
+                .isRead(false)
+                .articleTitle(articleTitle)
+                .targetId(targetId)
+                .build();
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/util/NotificationProperties.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/util/NotificationProperties.java
@@ -6,4 +6,5 @@ public class NotificationProperties {
     public static final String EVENT_NAME = "sse";
     public static final long DEFAULT_TIMEOUT = 3600L * 1000; //60분
     public static final int DELETE_AFTER_DAYS = 30; //알림 삭제 기한 (단위: 일)
+    public static final String NEW_NOTIFICATION_CREATED = "new notification created";
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/util/NotificationProperties.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/util/NotificationProperties.java
@@ -5,4 +5,5 @@ public class NotificationProperties {
     public static final String SEPARATOR = "_";
     public static final String EVENT_NAME = "sse";
     public static final long DEFAULT_TIMEOUT = 3600L * 1000; //60분
+    public static final int DELETE_AFTER_DAYS = 30; //알림 삭제 기한 (단위: 일)
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/notification/util/NotificationProperties.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/notification/util/NotificationProperties.java
@@ -1,0 +1,8 @@
+package dormitoryfamily.doomz.domain.notification.util;
+
+public class NotificationProperties {
+
+    public static final String SEPARATOR = "_";
+    public static final String EVENT_NAME = "sse";
+    public static final long DEFAULT_TIMEOUT = 3600L * 1000; //60분
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/request/MatchingRequestEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/request/MatchingRequestEvent.java
@@ -1,0 +1,10 @@
+package dormitoryfamily.doomz.domain.roommate.matching.event.request;
+
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+import dormitoryfamily.doomz.domain.roommate.matching.entity.MatchingRequest;
+
+public record MatchingRequestEvent(
+        MatchingRequest matchingRequest,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/request/MatchingRequestListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/request/MatchingRequestListener.java
@@ -1,0 +1,30 @@
+package dormitoryfamily.doomz.domain.roommate.matching.event.request;
+
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import dormitoryfamily.doomz.domain.roommate.matching.entity.MatchingRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import static dormitoryfamily.doomz.domain.notification.entity.type.NotificationType.MATCHING_REQUEST;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingRequestListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleMatchingRequestEvent(MatchingRequestEvent event) {
+        MatchingRequest matchingRequest = event.matchingRequest();
+        boolean isRequest = event.notificationType() == MATCHING_REQUEST;
+
+        Member receiver = isRequest ? matchingRequest.getReceiver() : matchingRequest.getSender();
+        Member sender = isRequest ? matchingRequest.getSender() : matchingRequest.getReceiver();
+
+        notificationService.send(receiver, sender, event.notificationType(), null, sender.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/result/MatchingResultEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/result/MatchingResultEvent.java
@@ -1,0 +1,10 @@
+package dormitoryfamily.doomz.domain.roommate.matching.event.result;
+
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+import dormitoryfamily.doomz.domain.roommate.matching.entity.MatchingResult;
+
+public record MatchingResultEvent(
+        MatchingResult matchingResult,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/result/MatchingResultListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/event/result/MatchingResultListener.java
@@ -1,0 +1,26 @@
+package dormitoryfamily.doomz.domain.roommate.matching.event.result;
+
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import dormitoryfamily.doomz.domain.roommate.matching.entity.MatchingResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingResultListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleMatchingResultEvent(MatchingResultEvent event) {
+        MatchingResult matchingResult = event.matchingResult();
+        Member receiver = matchingResult.getReceiver();
+        Member sender = matchingResult.getSender();
+
+        notificationService.send(receiver, sender, event.notificationType(), null, sender.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/wish/event/RoommateWishCreatedEvent.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/wish/event/RoommateWishCreatedEvent.java
@@ -1,0 +1,10 @@
+package dormitoryfamily.doomz.domain.roommate.wish.event;
+
+import dormitoryfamily.doomz.domain.notification.entity.type.NotificationType;
+import dormitoryfamily.doomz.domain.roommate.wish.entity.RoommateWish;
+
+public record RoommateWishCreatedEvent(
+        RoommateWish roommateWish,
+        NotificationType notificationType
+) {
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/wish/event/RoommateWishCreatedListener.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/wish/event/RoommateWishCreatedListener.java
@@ -1,0 +1,26 @@
+package dormitoryfamily.doomz.domain.roommate.wish.event;
+
+import dormitoryfamily.doomz.domain.member.member.entity.Member;
+import dormitoryfamily.doomz.domain.notification.service.NotificationService;
+import dormitoryfamily.doomz.domain.roommate.wish.entity.RoommateWish;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoommateWishCreatedListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Async
+    public void handleCommentCreatedEvent(RoommateWishCreatedEvent event) {
+        RoommateWish roommateWish = event.roommateWish();
+        Member wished = roommateWish.getWished();
+        Member wisher = roommateWish.getWisher();
+
+        notificationService.send(wished, wisher, event.notificationType(), null, wisher.getId());
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/ErrorCode.java
@@ -76,40 +76,40 @@ public enum ErrorCode {
     CHAT_NOT_EXISTS(BAD_REQUEST, "채팅 기록이 존재하지 않는 채팅방입니다."),
 
     //recommendation
-    RECOMMENDATION_NOT_EXISTS(HttpStatus.NOT_FOUND, "룸메이트 매칭 추천을 요청한 적이 없습니다."),
-    TOO_MANY_REQUEST(HttpStatus.BAD_REQUEST, "매칭 추천 가능은 " + RECOMMENDATION_INTERVAL_HOURS + "시간 내 한 번만 가능합니다."),
+    RECOMMENDATION_NOT_EXISTS(NOT_FOUND, "룸메이트 매칭 추천을 요청한 적이 없습니다."),
+    TOO_MANY_REQUEST(BAD_REQUEST, "매칭 추천 가능은 " + RECOMMENDATION_INTERVAL_HOURS + "시간 내 한 번만 가능합니다."),
 
     //lifestyle
-    ALREADY_REGISTER_MY_LIFESTYLE(HttpStatus.CONFLICT, "나의 라이프 스타일을 이미 설정했습니다."),
-    LIFESTYLE_TYPE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 생활 타입은 존재하지 않습니다."),
-    SLEEPING_TIME_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 취침 시간은 존재하지 않습니다."),
-    WAKE_UP_TIME_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 기상 시간은 존재하지 않습니다."),
-    SLEEPING_HABIT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 잠버릇은 존재하지 않습니다."),
-    SLEEPING_SENSITIVITY_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 잠귀 타입은 존재하지 않습니다."),
-    SMOKING_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 흡연 타입은 존재하지 않습니다."),
-    DRINKING_FREQUENCY_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 음주 빈도는 존재하지 않습니다."),
-    SHOWER_TIME_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 샤워 시간대는 존재하지 않습니다."),
-    SHOWER_DURATION_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 샤워 시간은 존재하지 않습니다."),
-    CLEANING_HABIT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 청소 타입은 존재하지 않습니다."),
-    HEAT_TOLERANCE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 더위 타입은 존재하지 않습니다."),
-    COLD_TOLERANCE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 추위 타입은 존재하지 않습니다."),
-    MBTI_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 MBTI 타입은 존재하지 않습니다."),
-    VISIT_HOME_FREQUENCY_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 본가 가는 빈도는 존재하지 않습니다."),
-    LATE_NIGHT_SNACK_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 야식 타입은 존재하지 않습니다."),
-    SNACK_IN_ROOM_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 방안에서 타입은 존재하지 않습니다."),
-    PHONE_SOUND_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 휴대폰 소리 타입은 존재하지 않습니다."),
-    PERFUME_USAGE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 향수 타입은 존재하지 않습니다."),
-    STUDY_LOCATION_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 공부 장소는 존재하지 않습니다."),
-    EXAM_PREPARATION_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 시험 타입은 존재하지 않습니다."),
-    EXERCISE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 운동 타입은 존재하지 않습니다."),
-    INSECT_TOLERANCE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "해당 벌레 타입은 존재하지 않습니다."),
-    LIFESTYLE_NOT_EXISTS(HttpStatus.NOT_FOUND, "생활 타입을 아직 설정하지 않았습니다."),
+    ALREADY_REGISTER_MY_LIFESTYLE(CONFLICT, "나의 라이프 스타일을 이미 설정했습니다."),
+    LIFESTYLE_TYPE_NOT_EXISTS(BAD_REQUEST, "해당 생활 타입은 존재하지 않습니다."),
+    SLEEPING_TIME_NOT_EXISTS(BAD_REQUEST, "해당 취침 시간은 존재하지 않습니다."),
+    WAKE_UP_TIME_NOT_EXISTS(BAD_REQUEST, "해당 기상 시간은 존재하지 않습니다."),
+    SLEEPING_HABIT_NOT_EXISTS(BAD_REQUEST, "해당 잠버릇은 존재하지 않습니다."),
+    SLEEPING_SENSITIVITY_NOT_EXISTS(BAD_REQUEST, "해당 잠귀 타입은 존재하지 않습니다."),
+    SMOKING_NOT_EXISTS(BAD_REQUEST, "해당 흡연 타입은 존재하지 않습니다."),
+    DRINKING_FREQUENCY_NOT_EXISTS(BAD_REQUEST, "해당 음주 빈도는 존재하지 않습니다."),
+    SHOWER_TIME_NOT_EXISTS(BAD_REQUEST, "해당 샤워 시간대는 존재하지 않습니다."),
+    SHOWER_DURATION_NOT_EXISTS(BAD_REQUEST, "해당 샤워 시간은 존재하지 않습니다."),
+    CLEANING_HABIT_NOT_EXISTS(BAD_REQUEST, "해당 청소 타입은 존재하지 않습니다."),
+    HEAT_TOLERANCE_NOT_EXISTS(BAD_REQUEST, "해당 더위 타입은 존재하지 않습니다."),
+    COLD_TOLERANCE_NOT_EXISTS(BAD_REQUEST, "해당 추위 타입은 존재하지 않습니다."),
+    MBTI_NOT_EXISTS(BAD_REQUEST, "해당 MBTI 타입은 존재하지 않습니다."),
+    VISIT_HOME_FREQUENCY_NOT_EXISTS(BAD_REQUEST, "해당 본가 가는 빈도는 존재하지 않습니다."),
+    LATE_NIGHT_SNACK_NOT_EXISTS(BAD_REQUEST, "해당 야식 타입은 존재하지 않습니다."),
+    SNACK_IN_ROOM_NOT_EXISTS(BAD_REQUEST, "해당 방안에서 타입은 존재하지 않습니다."),
+    PHONE_SOUND_NOT_EXISTS(BAD_REQUEST, "해당 휴대폰 소리 타입은 존재하지 않습니다."),
+    PERFUME_USAGE_NOT_EXISTS(BAD_REQUEST, "해당 향수 타입은 존재하지 않습니다."),
+    STUDY_LOCATION_NOT_EXISTS(BAD_REQUEST, "해당 공부 장소는 존재하지 않습니다."),
+    EXAM_PREPARATION_NOT_EXISTS(BAD_REQUEST, "해당 시험 타입은 존재하지 않습니다."),
+    EXERCISE_NOT_EXISTS(BAD_REQUEST, "해당 운동 타입은 존재하지 않습니다."),
+    INSECT_TOLERANCE_NOT_EXISTS(BAD_REQUEST, "해당 벌레 타입은 존재하지 않습니다."),
+    LIFESTYLE_NOT_EXISTS(NOT_FOUND, "생활 타입을 아직 설정하지 않았습니다."),
 
     //preference
-    ALREADY_REGISTER_PREFERENCE_ORDER(HttpStatus.CONFLICT, "선호 우선순위를 이미 설정했습니다."),
-    PREFERENCE_ORDER_NOT_EXISTS(HttpStatus.NOT_FOUND, "선호 우선순위가 설정되어 있지 않습니다."),
-    WRONG_PROPERTY(HttpStatus.BAD_REQUEST, "해당 프로퍼티는 유효하지 않습니다."),
-    DUPLICATE_PREFERENCE_ORDER_PARAMETER(HttpStatus.BAD_REQUEST, "타입이 중복됩니다."),
+    ALREADY_REGISTER_PREFERENCE_ORDER(CONFLICT, "선호 우선순위를 이미 설정했습니다."),
+    PREFERENCE_ORDER_NOT_EXISTS(NOT_FOUND, "선호 우선순위가 설정되어 있지 않습니다."),
+    WRONG_PROPERTY(BAD_REQUEST, "해당 프로퍼티는 유효하지 않습니다."),
+    DUPLICATE_PREFERENCE_ORDER_PARAMETER(BAD_REQUEST, "타입이 중복됩니다."),
 
     //matching request
     CANNOT_MATCHING_YOURSELF(CONFLICT, "자기 자신에게 매칭 신청을 할 수 없습니다."),
@@ -118,6 +118,7 @@ public enum ErrorCode {
     ALREADY_MATCHED_MEMBER(CONFLICT, "이미 룸메이트 매칭이 완료된 사용자입니다."),
     MEMBER_DORMITORY_MISMATCH(CONFLICT, "기숙사가 달라 매칭이 불가능한 사용자입니다."),
     MATCHING_REQUEST_STATUS_NOT_EXISTS(NOT_FOUND, "해당 매칭 신청 타입은 존재하지 않습니다."),
+
     //matching result
     MATCHING_RESULT_NOT_EXISTS(CONFLICT,"해당 사용자와 룸메이트 매칭이 이루어지지 않은 상태입니다." ),
 
@@ -125,6 +126,11 @@ public enum ErrorCode {
     ROOMMATE_WISH_NOT_EXIT(NOT_FOUND, "룸메이트 찜하지 않은 사용자입니다."),
     CANNOT_WISH_YOURSELF(CONFLICT, "자기 자신을 룸메이트 찜할 수 없습니다."),
     ALREADY_WISHED_ROOMMATE(CONFLICT, "이미 찜한 룸메이트 입니다."),
+
+    //notification
+    NOTIFICATION_NOT_EXISTS(NOT_FOUND, "해당 알림은 존재하지 않습니다."),
+    ALREADY_READ_NOTIFICATION(CONFLICT, "해당 알림은 이미 읽음 처리가 되어 있습니다."),
+    NOT_MY_NOTIFICATION(BAD_REQUEST, "본인 알림이 아닙니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)

### - **간략한 설명**
  - `SSE` 통신 기법을 이용하여 알림 기능을 구현했습니다.
  - 실시간 알림뿐만 아니라, `알림 리스트 조회`, `읽음 처리` API를 추가했습니다.
  - 생성 시기로부터 1개월 된 알림은 자동 삭제됩니다.

---

## 🛠 주요 작성/변경 사항

### - SSE를 통한 실시간 알림 구현
  - 클라이언트에서 SSE 구독 API를 요청하면 서버에서 SSE 연결을 진행합니다.
  - 각 계정당 연결을 담당할 Emitter과 연관된 이벤트를 저장할 ConcurrentHashMap을 `EmitterRepositoryImpl`가 가지고 있습니다.
    ```java
    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
    ```
    - 멀티 쓰레드 동시성 문제를 예방하기 위해서 `ConcurrentHashMap`을 사용했습니다.
  - `NotificationService`에서 SSE를 구독하는 로직은 다음과 같습니다.
    ```java
    public SseEmitter subscribe(PrincipalDetails principalDetails, String lastEventId) {
        Member loginMember = principalDetails.getMember();
        String emitterId = makeIdIncludedMemberEmail(loginMember.getEmail());

        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));

        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));

        sendDummyEventFor503Error(loginMember, emitter, emitterId);

        if (hasLostEvents(lastEventId)) {
            sendLostEvents(lastEventId, loginMember, emitter, emitterId);
        }

        return emitter;
    }
    ```
    1. 계정 이메일을 기준으로 `emiiter` 식별자 생성
        ```java
        String emitterId = makeIdIncludedMemberEmail(loginMember.getEmail());
        
        private static String makeIdIncludedMemberEmail(String memberEmail) {
          return memberEmail + SEPARATOR + System.currentTimeMillis();
        }
        ```
    2. 새로운 Emitter 생성 후 `emitterRepository`에 저장
        ```java
        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
        ```
    3. 콜백 함수를 호출하여 `emitter` 완료 또는 만료하면 저장소에서 삭제
        ```java
        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
        ```
    4. `503 예외`를 방지하기 위해 데이터 전달
        ```java
        sendDummyEventFor503Error(loginMember, emitter, emitterId);
        ```
        SSE 구독한 후 일정 시간내 아무런 데이터를 전송하지 않으면 503 에러가 발생하기 때문에 이를 방지하고자 클라이언트에 임의의 데이터를 전송합니다.
    5. 만약 네트워크 오류 등으로 클라이언트가 받지 못한 이벤트가 있다면 해당 이벤트(알림)을 마저 전달
        ```java
        if (hasLostEvents(lastEventId)) {
            sendLostEvents(lastEventId, loginMember, emitter, emitterId);
        }
        ```
    6. 클라이언트에게 생성한 `Emitter` 객체 전달
        ```java
        return emitter;
        ```
  이제 서버에서 새로운 이벤트(알림)을 전송하면 클라이언트는 실시간으로 알림을 받을 수 있습니다.

### - 특정 행위에 따른 실시간 알림 전송
  - 게시글에 대한 댓글 작성, 대댓글 작성, 게시글 찜, 팔로우, 채팅, 룸메이트 신청, 수락, 거절 등의 요청을 수행하면 해당 알림이 생성되어 DB에 저장되고 실시간 알림으로 클라이언트에 알려줍니다.
  - 실시간 알림의 경우, 초기엔 알림 내용을 전부 전달했습니다. 그러나 클라이언트 측에서 사용자에게 실시간 알림 내용을 보여주지 않는다는 정책상 굳이 데이터가 필요 없어서 단순 알림 생성 내역만 전달합니다. 클라이언트는 그 정보를 이용해서 알림 수신 신호인 빨간색 점을 생성합니다.
    ![Screen Shot 2024-08-20 at 6 41 09 PM](https://github.com/user-attachments/assets/0b02cf04-6b03-456b-b8db-f0a05ccbd3a6)

### - 알림 리스트 조회 API
  - 사용자가 알림 리스트를 조회하면 페이징을 사용하여 알림 데이터를 전송합니다.
  - 정렬 기준의 1순위는 `읽음 여부`(isRead)이고 `false` 값이 먼저 정렬됩니다.
  - 정렬 기준의 2순위는 `생성 시기`(createdAt)이고 `최신순`으로 정렬됩니다.

### - 알림 읽음 처리 API
  - 클라이언트에서 읽음 처리를 원하는 알림 Id를 배열로 요청합니다.
  - 3가지 예외 처리가 되어 있습니다.
    1. 해당 알림 Id가 존재하지 않은 경우
    2. 해당 알림이 이미 읽음 처리가 되어 있는 경우
    3. 해당 알림이 내 알림이 아닌 경우

### - 1개월 지난 알림이 자동으로 삭제
  - 스프링 스케줄러 애노테이션을 이용하여 알림 생성된 지 1개월이 지나면 자동으로 DB로부터 삭제됩니다.
  - 매일 자정에 삭제 로직이 수행됩니다. 미세한 시간 설정이 중요하지 않기 때문에 성능을 위해서 하루 한 번만 해당 로직을 수행합니다.
    ```java
    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
    @Transactional
    public void deleteOldNotifications() {
        LocalDateTime oneMonthAgo = LocalDateTime.now().minusDays(DELETE_AFTER_DAYS);
        notificationRepository.deleteByCreatedAtBefore(oneMonthAgo);
    }
    ```

---

## 💡 특이 사항 및 고민사항

### - 알림 기능을 구현하기 위한 고민 `AOP` vs `이벤트 발행 & 리스닝`
  - 특정 요청이 완료될 때 알림을 생성하고 실시간 알림을 전송하는 로직을 어떻게 해야할지 고민을 많이 했습니다.
  - 처음 고안했던 방안은 `AOP` 입니다. 중복 코드를 줄이고 유지 보수에 좋다고 판단했기 때문입니다. 그래서 애노테이션으로 생성한 뒤 특정 요청 서비스 계층 메소드를 포인트컷으로 지정하려고 했습니다. 
  하지만 알림 생성에 필요한 데이터(타겟 id, 발신자 닉네임, 게시글 제목 등)들을 지정된 메소드의 반환 객체에서 가져와야 하는데, 댓글 작성, 게시글 찜하기, 채팅, 룸메이트 신청 등 반환 타입이 전부 상이해서 통일된 AOP로 지정하는데 어려움이 있었습니다. 
  - 대안으로, 각 알림 타입마다 이벤트를 생성하고 이벤트 발행과 리스너를 구현했습니다. 각각의 서비스 계층이 바로 알림에 의존하지 않고 이벤트 `Publisher`에 의존하게 함으로써 `결합도`를 줄이고자 했습니다.

### - 알림이 생성되지 않는 조건
  - 본인이 작성한 게시글에 댓글, 찜하기를 요청해도 알림은 생성되지 않습니다.
  - 본인이 작성한 댓글에 대댓글을 작성해도 알림은 생성되지 않습니다.
  - 채팅방에 들어가 있거나 이미 채팅 알림이 생성되어 있다면 추가적인 알림은 생성되지 않습니다.
    - 많은 데이터가 전송되는 채팅마다 알림을 생성하면 비효율적이라 판단했습니다.

### - 읽음 처리 API 따로 둔 이유
  - 초기엔 알림 리스트를 조회하는 동시에 바로 해당 알림들을 `읽음 처리`하고자 했습니다.
  그러나 페이징 처리로 인해 DB에서 조회할 때마다 위에서 언급한 정렬 조건(읽음 처리)이 반영되는데, 1페이지 조회 후 바로 읽음 처리를 해버리면 2페이지 조회 시 이전 조회때와 동일하지 못한 상황임으로 조회되는 데이터가 꼬이게 됩니다.
  - 이를 해결하고자, 페이징을 통해 원하는 만큼의 리스트 조회가 끝난 뒤 능동적으로 읽음 처리를 요청하는 API를 따로 생성했습니다.

---

## 🔗 관련 이슈

- **이슈 링크** : #143 

---

## 📮 리뷰어에게 전하는 메시지
- 리뷰 부탁드립니다. 감사합니다!
