### PR TITLE
[Fix] 나의 라이프스타일(Lifestyle) 중 선택 항목들 값 초기화 가능하도록 수정

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/ExerciseType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/ExerciseType.java
@@ -17,7 +17,7 @@ public enum ExerciseType {
     }
 
     public static ExerciseType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/InsectToleranceType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/InsectToleranceType.java
@@ -17,7 +17,7 @@ public enum InsectToleranceType {
     }
 
     public static InsectToleranceType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/LateNightSnackType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/LateNightSnackType.java
@@ -17,7 +17,7 @@ public enum LateNightSnackType {
     }
 
     public static LateNightSnackType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/MBTIType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/MBTIType.java
@@ -12,7 +12,7 @@ public enum MBTIType {
     ESTJ, ESFJ, ENFJ, ENTJ;
 
     public static MBTIType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/PhoneSoundType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/PhoneSoundType.java
@@ -17,7 +17,7 @@ public enum PhoneSoundType {
     }
 
     public static PhoneSoundType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/ShowerDurationType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/ShowerDurationType.java
@@ -19,7 +19,7 @@ public enum ShowerDurationType {
     }
 
     public static ShowerDurationType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/ShowerTimeType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/ShowerTimeType.java
@@ -16,7 +16,7 @@ public enum ShowerTimeType {
     }
 
     public static ShowerTimeType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/SnackInRoomType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/SnackInRoomType.java
@@ -16,7 +16,7 @@ public enum SnackInRoomType {
     }
 
     public static SnackInRoomType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/StudyLocationType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/StudyLocationType.java
@@ -17,7 +17,7 @@ public enum StudyLocationType {
     }
 
     public static StudyLocationType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/VisitHomeFrequencyType.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/lifestyle/entity/type/VisitHomeFrequencyType.java
@@ -18,7 +18,7 @@ public enum VisitHomeFrequencyType {
     }
 
     public static VisitHomeFrequencyType fromDescription(String description) {
-        if(description == null) {
+        if(description == null || description.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/dormitoryfamily/doomz/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/dormitoryfamily/doomz/global/exception/GlobalExceptionRestAdvice.java
@@ -38,17 +38,16 @@ public class GlobalExceptionRestAdvice {
 
     @ExceptionHandler
     public ResponseEntity<ResponseDto<Void>> handleDbException(DataAccessException e) {
-        System.out.println("e.getMessage() = " + e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ResponseDto.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "DB 에러!"));
+                .body(ResponseDto.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "DB 에러!" + e.getMessage()));
     }
 
     @ExceptionHandler
     public ResponseEntity<ResponseDto<Void>> handleServerException(RuntimeException e) {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ResponseDto.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
+                .body(ResponseDto.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!" + e.getMessage()));
     }
 
     //@Validate 검증 예외 처리


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 버그 수정 (Bug Fix)

### - **간략한 설명**
  - 사용자의 라이프스타일(Lifestyle) 중 선택 항목 값을 초기화(null)로 만들 수 있도록 수정했습니다.

---

## 🛠 주요 작성/변경 사항

  - 라이프스타일 수정 API에서 수정하지 않을 항목은 DTO에 포함시키지 않습니다. 그러면 `null` 값으로 처리되기 때문에 `PATCH` 메소드로 수정 로직을 처리할 수 있었습니다.
  - 하지만 의도적으로 특정 선택 항목을 초기화(null)로 만들고자 할 때 올바르게 처리되지 못하는 문제가 발생했습니다.
  - 이를 해결하고자, 값을 초기화하고 싶은 항목에 대해선 `""` 값으로 요청을 받아서 `isEmpty()` 메소드로 처리를 할 수 있도록 만들었습니다.
    ```json
    {
      "visitHomeFrequency": "", 
      "lateNightSnack": ""
    }
    ```

## 📮 리뷰어에게 전하는 메시지
- 예전에 isEmpty() 메소드가 왜 있냐고 질문하셨는데, 이제서야 그 용도를 알게 되었습니다 ㅎㅎ 
