### PR TITLE
[Feature] 매칭 완료된 사용자 Id 반환 & 특정 Id에 대한 팔로우 여부 반환

### DIFF
--- a/src/main/java/dormitoryfamily/doomz/domain/member/follow/controller/FollowController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/follow/controller/FollowController.java
@@ -1,8 +1,8 @@
 package dormitoryfamily.doomz.domain.member.follow.controller;
 
-import dormitoryfamily.doomz.domain.member.member.dto.response.MemberProfileListResponseDto;
-import dormitoryfamily.doomz.domain.member.member.dto.response.MemberProfilePagingListResponseDto;
+import dormitoryfamily.doomz.domain.member.follow.dto.FollowStatusResponseDto;
 import dormitoryfamily.doomz.domain.member.follow.service.FollowService;
+import dormitoryfamily.doomz.domain.member.member.dto.response.MemberProfilePagingListResponseDto;
 import dormitoryfamily.doomz.global.security.dto.PrincipalDetails;
 import dormitoryfamily.doomz.global.util.ResponseDto;
 import dormitoryfamily.doomz.global.util.SearchRequestDto;
@@ -86,4 +86,12 @@ public class FollowController {
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 
+    @GetMapping("/{memberId}/follow-status")
+    public ResponseEntity<ResponseDto<FollowStatusResponseDto>> checkFollowing(
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        FollowStatusResponseDto responseDto = followService.checkFollowing(principalDetails, memberId);
+        return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
+    }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/member/follow/dto/FollowStatusResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/follow/dto/FollowStatusResponseDto.java
@@ -1,0 +1,9 @@
+package dormitoryfamily.doomz.domain.member.follow.dto;
+
+public record FollowStatusResponseDto(
+        boolean isFollowing
+) {
+    public static FollowStatusResponseDto from(boolean isFollowing) {
+        return new FollowStatusResponseDto(isFollowing);
+    }
+}

--- a/src/main/java/dormitoryfamily/doomz/domain/member/follow/service/FollowService.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/follow/service/FollowService.java
@@ -1,5 +1,6 @@
 package dormitoryfamily.doomz.domain.member.follow.service;
 
+import dormitoryfamily.doomz.domain.member.follow.dto.FollowStatusResponseDto;
 import dormitoryfamily.doomz.domain.member.follow.entity.Follow;
 import dormitoryfamily.doomz.domain.member.follow.event.FollowCreatedEvent;
 import dormitoryfamily.doomz.domain.member.follow.exception.AlreadyFollowingException;
@@ -159,4 +160,14 @@ public class FollowService {
         return MemberProfilePagingListResponseDto.from(follows, memberProfiles);
     }
 
+    public FollowStatusResponseDto checkFollowing(PrincipalDetails principalDetails, Long followingId) {
+        Member loginMember = principalDetails.getMember();
+        Member following = getMemberById(followingId);
+
+        if (loginMember.getId().equals(followingId)) {
+            throw new CannotFollowYourselfException();
+        }
+
+        return FollowStatusResponseDto.from(followRepository.existsByFollowerAndFollowing(loginMember, following));
+    }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/member/member/controller/MemberController.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/member/controller/MemberController.java
@@ -80,11 +80,11 @@ public class MemberController {
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 
-    @GetMapping("/my/matching-statuses")
+    @GetMapping("/my/matching-status")
     public ResponseEntity<ResponseDto<MatchingStatusResponseDto>> getMyRoommateMatchingStatus(
             @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        MatchingStatusResponseDto responseDto = memberService.getMyMatchingStatus(principalDetails);
+        MatchingStatusResponseDto responseDto = memberService.getMyMatchedId(principalDetails);
         return ResponseEntity.ok(ResponseDto.okWithData(responseDto));
     }
 

--- a/src/main/java/dormitoryfamily/doomz/domain/member/member/dto/response/MatchingStatusResponseDto.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/member/member/dto/response/MatchingStatusResponseDto.java
@@ -1,11 +1,9 @@
 package dormitoryfamily.doomz.domain.member.member.dto.response;
 
-import dormitoryfamily.doomz.domain.member.member.entity.Member;
-
 public record MatchingStatusResponseDto(
-        boolean isRoommateMatched
+        Long matchedId
 ) {
-    public static MatchingStatusResponseDto from(Member member){
-        return new MatchingStatusResponseDto(member.isRoommateMatched());
+    public static MatchingStatusResponseDto from(Long matchedId){
+        return new MatchingStatusResponseDto(matchedId);
     }
 }

--- a/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/repository/MatchingResultRepository.java
+++ b/src/main/java/dormitoryfamily/doomz/domain/roommate/matching/repository/MatchingResultRepository.java
@@ -13,4 +13,7 @@ public interface MatchingResultRepository extends JpaRepository<MatchingResult, 
             "WHERE (m.sender = :loginMember AND m.receiver = :targetMember) " +
             "OR (m.sender = :targetMember AND m.receiver = :loginMember)")
     Optional<MatchingResult> findByMembers(Member loginMember, Member targetMember);
+
+    @Query("SELECT m FROM MatchingResult m WHERE m.sender = :member OR m.receiver = :member")
+    Optional<MatchingResult> findBySenderOrReceiver(Member member);
 }


### PR DESCRIPTION
<!--  (PR시 지우세요!)
@@@ PR에 포함되어야 하는 내용 @@@ 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->

## 🎯 목적

- [x] 새 기능 (New Feature)

### - **간략한 설명**
  - 로그인 사용자가 매칭이 완료된 상태를 기존 `boolean` 값에서 `매칭 상대 Id` 또는 `0`으로 반환하도록 변경했습니다.
  - 특정 사용자를 팔로우하고 있는지 여부를 반환하는 API를 추가했습니다.

---

## 🛠 주요 작성/변경 사항

### - 매칭 완료된 Id 또는 0 반환
  - 프론트에서 룸메 매칭 홈 화면에서 로그인 사용자가 매칭된 사용자 Id가 필요하단 요청을 받았습니다.
  - 매칭 여부를 `boolean`으로 반환하던 기존 API를 수정하여, 매칭이 된 상태라면 해당 `Id`를 반환하고, 매칭이 되지 않은 상태라면 `0`을 반환합니다.

### - 특정 사용자를 팔로우 하는 여부 조회 API 생성
  - 특정 사용자 Id를 통해 로그인 사용자가 대상을 팔로우 하고 있는지 boolean 타입으로 반환합니다.
  - 매칭을 위한 추천된 전체 인원을 조회할 때, 추천 받은 대상이 현재 내가 팔로우를 하고 있는지 여부를 확인하는 용도입니다.

---

## 💡 특이 사항 및 고민사항

### - 기존 매칭용 프로필 조회 API에 통합할지 여부를 고민했습니다.
  - 기존 `/api/matchings/members/{memberId}/profiles`의 응답 바디에 isFollowed 값을 추가할지, 아예 새로운 API를 생성할지 고민했습니다.
  - 추천 전체 인원 조회가 아닌 다른 영역에서 기존 API가 사용되고 있으므로, 기존 API에 추가한다면 팔로우 여부를 확인하는 작업이 불필요하게 반복 동작하게 됩니다.
  - 기존 API가 추천 전체 인원 조회 기능보다 다른 영역에서 더 많이 사용된다는 점을 고려해서 아예 새로운 API를 생성했습니다.
 
---

## 🔗 관련 이슈

- **이슈 링크** : #151 

---

## 📮 리뷰어에게 전하는 메시지
- 매칭 여부를 확인하는 엔드포인트에서 status가 복수형으로 더 자연스럽다는 자료를 봐서 수정했습니다.
- 리뷰 부탁드립니다!
